### PR TITLE
Auto switch to AP mode on start

### DIFF
--- a/lib/wizard/web/endpoint.ex
+++ b/lib/wizard/web/endpoint.ex
@@ -12,24 +12,76 @@ defmodule VintageNet.Wizard.Web.Endpoint do
 
   @impl Supervisor
   def init(_args) do
-    children = [
-      Plug.Cowboy.child_spec(
-        scheme: :http,
-        plug: Router,
-        options: [port: 4001, dispatch: dispatch()]
-      )
-    ]
-
-    Supervisor.init(children, strategy: :one_for_one)
+    Supervisor.init(make_children(), strategy: :one_for_one)
   end
 
-  defp dispatch do
+  defp dispatch(initial_scan) do
     [
       {:_,
        [
-         {"/socket", Socket, []},
+         {"/socket", Socket, [initial_scan]},
          {:_, Plug.Cowboy.Handler, {Router, []}}
        ]}
     ]
+  end
+
+  defp make_children() do
+    if should_start_ap_mode?() do
+      {:ok, initial_scan} = switch_to_ap_mode()
+
+      [
+        Plug.Cowboy.child_spec(
+          scheme: :http,
+          plug: Router,
+          options: [port: 4001, dispatch: dispatch(initial_scan)]
+        )
+      ]
+    else
+      []
+    end
+  end
+
+  defp should_start_ap_mode?() do
+    config = VintageNet.get_configuration("wlan0")
+
+    with {:ok, wifi} <- Map.fetch(config, :wifi),
+         {:ok, _} <- Map.fetch(wifi, :ssid) do
+      false
+    else
+      :error -> true
+    end
+  end
+
+  defp switch_to_ap_mode() do
+    config = %{
+      type: VintageNet.Technology.WiFi,
+      wifi: %{
+        mode: :host,
+        ssid: "VintageNet Wizard",
+        key_mgmt: :none,
+        scan_ssid: 1,
+        ap_scan: 1,
+        bgscan: :simple
+      },
+      ipv4: %{
+        method: :static,
+        address: "192.168.24.1",
+        netmask: "255.255.255.0"
+      },
+      dhcpd: %{
+        start: "192.168.24.2",
+        end: "192.168.24.10"
+      }
+    }
+
+    _ = VintageNet.scan("wlan0")
+
+    :timer.sleep(2_000)
+
+    initial_scan = VintageNet.get(["interface", "wlan0", "wifi", "access_points"])
+
+    :ok = VintageNet.configure("wlan0", config)
+
+    {:ok, initial_scan}
   end
 end


### PR DESCRIPTION
When vintage net wizard starts it will check if the WiFi is configured, if it is not it will switch WiFi to AP mode.

If the wifi is configured we won't start any of the web stuff.

Right now this only supports if the WiFi module cannot scan in AP mode, I plan on immediately working on being able to configure if we should scan while in AP mode or not. Things are hardcoded that could/should be configured but I am trying to make things work in a really well-known state first.

The 2 second sleep is arbitrary and I am not sold on it, so if there are better ideas on how to get that working the way we need it to I am open to suggestions :smile: 