### PR TITLE
Refactor logic about scanning to be in seperate module

### DIFF
--- a/lib/wizard/application.ex
+++ b/lib/wizard/application.ex
@@ -12,7 +12,8 @@ defmodule VintageNet.Wizard.Application do
 
   def children(:host) do
     [
-      VintageNet.Wizard.Web.Endpoint
+      VintageNet.Wizard.Web.Endpoint,
+      {VintageNet.Wizard.Backend, [VintageNet.Wizard.Backend.Host]}
     ]
   end
 

--- a/lib/wizard/web/backend.ex
+++ b/lib/wizard/web/backend.ex
@@ -1,0 +1,73 @@
+defmodule VintageNet.Wizard.Backend do
+  use GenServer
+
+  @callback init() :: {:ok, state :: any()}
+
+  @callback scan() :: :ok
+
+  @callback access_points(state :: any()) :: map()
+
+  @callback handle_info(any(), state :: any()) ::
+              {:reply, any(), state :: any()} | {:noreply, state :: any()}
+
+  defmodule State do
+    defstruct subscriber: nil, backend: nil, backend_state: nil
+  end
+
+  def start_link([backend]) do
+    GenServer.start_link(__MODULE__, backend, name: __MODULE__)
+  end
+
+  def subscribe() do
+    GenServer.cast(__MODULE__, {:subscribe, self()})
+  end
+
+  def access_points() do
+    GenServer.call(__MODULE__, :access_points)
+  end
+
+  def save(cfg) do
+    IO.inspect(cfg, label: "CFG")
+    :ok
+  end
+
+  def init(backend) do
+    {:ok, backend_state} = apply(backend, :init, [])
+    {:ok, %State{backend: backend, backend_state: backend_state}, {:continue, :scan}}
+  end
+
+  def handle_continue(:scan, %State{backend: backend} = state) do
+    :ok = apply(backend, :scan, [])
+    {:noreply, state}
+  end
+
+  def handle_call(
+        :access_points,
+        _from,
+        %State{backend: backend, backend_state: backend_state} = state
+      ) do
+    access_points = apply(backend, :access_points, [backend_state])
+    {:reply, access_points, state}
+  end
+
+  def handle_cast({:subscribe, subscriber}, state) do
+    {:noreply, %{state | subscriber: subscriber}}
+  end
+
+  def handle_info(
+        info,
+        %State{subscriber: subscriber, backend: backend, backend_state: backend_state} = state
+      ) do
+    case apply(backend, :handle_info, [info, backend_state]) do
+      {:reply, message, new_backend_state} ->
+        maybe_send(subscriber, {VintageNet.Wizard, message})
+        {:noreply, %{state | backend_state: new_backend_state}}
+
+      {:noreply, new_backend_state} ->
+        {:noreply, %{state | backend_state: new_backend_state}}
+    end
+  end
+
+  defp maybe_send(nil, _message), do: :ok
+  defp maybe_send(pid, message), do: send(pid, message)
+end

--- a/lib/wizard/web/host.ex
+++ b/lib/wizard/web/host.ex
@@ -1,0 +1,76 @@
+defmodule VintageNet.Wizard.Backend.Host do
+  @behaviour VintageNet.Wizard.Backend
+
+  def init(), do: {:ok, %{}}
+
+  def scan() do
+    access_points = %{
+      "04:18:d6:47:1a:6a" => %{
+        band: :wifi_2_4_ghz,
+        bssid: "04:18:d6:47:1a:6a",
+        channel: 6,
+        flags: [:wpa2_psk_ccmp, :ess],
+        frequency: 2462,
+        signal_dbm: -89,
+        signal_percent: 10,
+        ssid: "WirelessPCU"
+      },
+      "16:18:d6:47:1a:6a" => %{
+        band: :wifi_2_4_ghz,
+        bssid: "16:18:d6:47:1a:6a",
+        channel: 6,
+        flags: [:wpa2_psk_ccmp, :ess],
+        frequency: 2462,
+        signal_dbm: -90,
+        signal_percent: 9,
+        ssid: ""
+      },
+      "06:18:d6:47:1a:6a" => %{
+        band: :wifi_2_4_ghz,
+        bssid: "06:18:d6:47:1a:6a",
+        channel: 6,
+        flags: [:wpa2_psk_ccmp, :ess],
+        frequency: 2462,
+        signal_dbm: -90,
+        signal_percent: 9,
+        ssid: "WirelessPCU - Guest"
+      },
+      "26:9e:db:0d:4f:21" => %{
+        band: :wifi_2_4_ghz,
+        bssid: "26:9e:db:0d:4f:21",
+        channel: 6,
+        flags: [],
+        frequency: 2462,
+        signal_dbm: -61,
+        signal_percent: 60,
+        ssid: "SETUP"
+      },
+      "26:9e:db:0d:4f:22" => %{
+        band: :wifi_2_4_ghz,
+        bssid: "26:9e:db:0d:4f:22",
+        channel: 6,
+        flags: [:wpa2_eap_ccmp, :ess],
+        frequency: 2462,
+        signal_dbm: -61,
+        signal_percent: 80,
+        ssid: "enterprise"
+      }
+    }
+
+    send(
+      self(),
+      {VintageNet, ["interface", "wlan0", "wifi", "access_points"], %{}, access_points, %{}}
+    )
+
+    :ok
+  end
+
+  def access_points(state), do: state
+
+  def handle_info(
+        {VintageNet, ["interface", "wlan0", "wifi", "access_points"], _, access_points, _},
+        _
+      ) do
+    {:reply, {:access_points, access_points}, access_points}
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,8 @@ defmodule VintageNet.Wizard.MixProject do
   def application do
     [
       mod: {VintageNet.Wizard.Application, []},
-      extra_applications: [:logger, :runtime_tools, :eex]
+      extra_applications: [:logger, :runtime_tools, :eex],
+      included_applications: [:vintage_net, :nerves_runtime]
     ]
   end
 


### PR DESCRIPTION
This is a WIP on the start pulling out scanning and access point management from the socket code.

To kick things off I was just trying to make host/local development work and will follow up with making target development work.

Some questions:

1. On host machines do we want to start `vintage_net` and `nerves_runtime`?

I put those in `:included_applications` just so I can `iex -S mix` without running into errors or having to add any configs. This is added just so I can move forward and I don't have intention in suggesting that is the correct answer, but I am also not quite sure what the correct answer is off the top of my head.

2. I pick a random name for this new module/bahaviour `Backend` just to have a name. I am still thinking about a better name, so if any jump into your head let me know.

Note this the first PR in few to come to refactor more out and provide support to run on a target and do AP mode management.

To keep the PR small I did not clean up the Socket code to pull out the socket managing access points too, but if you want me to add that I can. I was going to do that next.