### PR TITLE
Remove need for included_applications via config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,0 +1,12 @@
+use Mix.Config
+
+# Configure :nerves_runtime and :vintage_net so that they will run on the host.
+# This is needed to run and debug locally
+config :nerves_runtime,
+  target: "host"
+
+config :vintage_net,
+  resolvconf: "/dev/null",
+  persistence_dir: "./persistence",
+  bin_ip: "false"
+

--- a/mix.exs
+++ b/mix.exs
@@ -15,8 +15,7 @@ defmodule VintageNet.Wizard.MixProject do
   def application do
     [
       mod: {VintageNet.Wizard.Application, []},
-      extra_applications: [:logger, :runtime_tools, :eex],
-      included_applications: [:vintage_net, :nerves_runtime]
+      extra_applications: [:logger, :runtime_tools, :eex]
     ]
   end
 


### PR DESCRIPTION
The use of included_applications might end up causing confusion. Both
vintage_net and nerves_runtime can be run on the host if configured
right, so do that instead.