### PR TITLE
Auto detect if WiFi needs configuration

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -9,3 +9,5 @@ config :vintage_net,
   resolvconf: "/dev/null",
   persistence_dir: "./persistence",
   bin_ip: "false"
+
+import_config "#{Mix.env()}.exs"

--- a/config/dev.exs
+++ b/config/dev.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/docs.exs
+++ b/config/docs.exs
@@ -1,0 +1,1 @@
+use Mix.Config

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,0 +1,4 @@
+use Mix.Config
+
+config :vintage_net_wizard,
+  backend: VintageNetWizard.Test.Backend

--- a/lib/vintage_net_wizard/application.ex
+++ b/lib/vintage_net_wizard/application.ex
@@ -12,8 +12,8 @@ defmodule VintageNetWizard.Application do
 
   def children(:host) do
     [
-      VintageNetWizard.Web.Endpoint,
-      {VintageNetWizard.Backend, [VintageNetWizard.Backend.Host]}
+      {VintageNetWizard.Backend, [Application.get_env(:vintage_net_wizard, :backend)]},
+      VintageNetWizard.Web.Endpoint
     ]
   end
 

--- a/lib/vintage_net_wizard/web/endpoint.ex
+++ b/lib/vintage_net_wizard/web/endpoint.ex
@@ -12,15 +12,7 @@ defmodule VintageNetWizard.Web.Endpoint do
 
   @impl Supervisor
   def init(_args) do
-    children = [
-      Plug.Cowboy.child_spec(
-        scheme: :http,
-        plug: Router,
-        options: [port: 4001, dispatch: dispatch()]
-      )
-    ]
-
-    Supervisor.init(children, strategy: :one_for_one)
+    Supervisor.init(make_children(), strategy: :one_for_one)
   end
 
   defp dispatch do
@@ -31,5 +23,57 @@ defmodule VintageNetWizard.Web.Endpoint do
          {:_, Plug.Cowboy.Handler, {Router, []}}
        ]}
     ]
+  end
+
+  defp make_children() do
+    if should_start_ap_mode?() do
+      :ok = switch_to_ap_mode()
+
+      [
+        Plug.Cowboy.child_spec(
+          scheme: :http,
+          plug: Router,
+          options: [port: 4001, dispatch: dispatch()]
+        )
+      ]
+    else
+      []
+    end
+  end
+
+  defp should_start_ap_mode?() do
+    config = VintageNet.get_configuration("wlan0")
+
+    with {:ok, wifi} <- Map.fetch(config, :wifi),
+         {:ok, _} <- Map.fetch(wifi, :ssid) do
+      false
+    else
+      :error -> true
+    end
+  end
+
+  defp switch_to_ap_mode() do
+    config = %{
+      type: VintageNet.Technology.WiFi,
+      wifi: %{
+        mode: :host,
+        ssid: "VintageNet Wizard",
+        key_mgmt: :none,
+        scan_ssid: 1,
+        ap_scan: 1,
+        bgscan: :simple
+      },
+      ipv4: %{
+        method: :static,
+        address: "192.168.24.1",
+        netmask: "255.255.255.0"
+      },
+      dhcpd: %{
+        start: "192.168.24.2",
+        end: "192.168.24.10"
+      }
+    }
+
+    VintageNet.configure("wlan0", config)
   end
 end

--- a/lib/vintage_net_wizard/web/host.ex
+++ b/lib/vintage_net_wizard/web/host.ex
@@ -68,7 +68,16 @@ defmodule VintageNetWizard.Backend.Host do
   end
 
   @impl true
+  def configured?(), do: false
+
+  @impl true
+  def configure(_state), do: :ok
+
+  @impl true
   def access_points(state), do: state
+
+  @impl true
+  def save(_cfg, state), do: {:ok, state}
 
   @impl true
   def handle_info(

--- a/lib/vintage_net_wizard/web/socket.ex
+++ b/lib/vintage_net_wizard/web/socket.ex
@@ -50,7 +50,7 @@ defmodule VintageNetWizard.Web.Socket do
 
   # Message from JS indicating the data should be saved
   def websocket_handle({:json, %{"type" => "save"}}, state) do
-    Backend.save(state.wifi_cfg)
+    _ = Backend.save(state.wifi_cfg)
     {:ok, state}
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule VintageNetWizard.MixProject do
       app: :vintage_net_wizard,
       version: @version,
       elixir: "~> 1.8",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: dialyzer(),
@@ -27,6 +28,9 @@ defmodule VintageNetWizard.MixProject do
   defp description do
     "WiFi Setup Wizard that uses VintageNet"
   end
+
+  def elixirc_paths(:test), do: ["test/support", "lib"]
+  def elixirc_paths(_), do: ["lib"]
 
   defp package do
     %{

--- a/test/support/test_backend.ex
+++ b/test/support/test_backend.ex
@@ -1,0 +1,26 @@
+defmodule VintageNetWizard.Test.Backend do
+  @behaviour VintageNetWizard.Backend
+
+  @impl true
+  def init() do
+    {:ok, nil}
+  end
+
+  @impl true
+  def scan(), do: :ok
+
+  @impl true
+  def access_points(_), do: %{}
+
+  @impl true
+  def configured?(), do: true
+
+  @impl true
+  def save(_cfg, state), do: {:ok, state}
+
+  @impl true
+  def configure(_state), do: :ok
+
+  @impl true
+  def handle_info(_, state), do: {:noreply, state}
+end


### PR DESCRIPTION
Didn't add configuration of the port and stuff, but will make a follow-up PR for that in future.

Checks if WiFi is configured, if so nothing happens and if not we will start the web stuff.

Allows us to run tests with a test backend.

I think in the next step of making this work on targets the backend behaviour will evolve more and become better.