### PR TITLE
Refactor to use WiFiConfiguration

### DIFF
--- a/lib/vintage_net_wizard/backend/default.ex
+++ b/lib/vintage_net_wizard/backend/default.ex
@@ -11,7 +11,7 @@ defmodule VintageNetWizard.Backend.Default do
       :ok = VintageNet.subscribe(["interface", "wlan0", "state"])
       :ok = VintageNet.subscribe(["interface", "wlan0", "wifi", "access_points"])
       :ok = switch_to_ap_mode()
-      {:ok, %{access_points: %{}, cfg: %{}}}
+      {:ok, %{access_points: %{}}}
     end
   end
 
@@ -36,19 +36,14 @@ defmodule VintageNetWizard.Backend.Default do
   end
 
   @impl true
-  def save(cfg, state) do
-    {:ok, %{state | cfg: cfg}}
-  end
-
-  @impl true
-  def configure(%{cfg: cfg}) do
+  def configure([cfg], _) do
     VintageNet.configure("wlan0", %{
       type: VintageNet.Technology.WiFi,
       wifi: %{
-        ssid: cfg["ssid"],
-        psk: cfg["psk"],
+        ssid: cfg.ssid,
+        psk: cfg.password,
         mode: :client,
-        key_mgmt: :wpa_psk
+        key_mgmt: cfg.key_mgmt
       },
       ipv4: %{method: :dhcp}
     })

--- a/lib/vintage_net_wizard/backend/mock.ex
+++ b/lib/vintage_net_wizard/backend/mock.ex
@@ -22,7 +22,7 @@ defmodule VintageNetWizard.Backend.Mock do
         frequency: 2462,
         signal_dbm: -90,
         signal_percent: 9,
-        ssid: ""
+        ssid: "CIA"
       },
       "06:18:d6:47:1a:6a" => %{
         band: :wifi_2_4_ghz,
@@ -68,13 +68,10 @@ defmodule VintageNetWizard.Backend.Mock do
   def configured?(), do: false
 
   @impl true
-  def configure(_state), do: :ok
+  def configure(_cfgs, _state), do: :ok
 
   @impl true
   def access_points(state), do: state
-
-  @impl true
-  def save(_cfg, state), do: {:ok, state}
 
   @impl true
   def handle_info(_, state) do

--- a/lib/vintage_net_wizard/wifi_configuration.ex
+++ b/lib/vintage_net_wizard/wifi_configuration.ex
@@ -38,14 +38,27 @@ defmodule VintageNetWizard.WiFiConfiguration do
   def decode(json) do
     case Jason.decode(json) do
       {:ok, params} ->
-        from_params(params)
+        from_map(params)
 
       {:error, decode_error} ->
         {:error, :json_decode, decode_error}
     end
   end
 
-  defp from_params(params) do
+  @doc """
+  Try to make a WiFiConfiguration from a map.
+
+  Required fields:
+
+    - "ssid" - The SSID of the access point
+    - "key_mgmt" - The key management to use
+
+  Options fields:
+
+    - "password" - The passowrd for the access point
+  """
+  @spec from_map(map()) :: {:ok, t()} | {:error, param_error(), value :: any()}
+  def from_map(params) do
     with {:ok, ssid} <- ssid_from_params(params),
          {:ok, key_mgmt} <- key_mgmt_from_params(params),
          password <- params["password"] do

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -58,8 +58,8 @@ const handle_scanned_ssid = function (data, table_id) {
         key_mgmtRow.getElementsByClassName("key_mgmtinput")[0].value = "wpa_psk";
         var pskRow = newTbody.insertRow();
         pskRow.innerHTML = `
-        <label for="input-psk"> Passphrase </label>
-        <input type="password" name="psk" id="input-psk">
+        <label for="input-password"> Passphrase </label>
+        <input type="password" name="password" id="input-password">
         `;
       }
 


### PR DESCRIPTION
Refactored to use `WiFiConfiguration` struct and pulled the runtime configuration state out of the backend implementation modules. It seems that those modules should know how to apply configurations, but they don't really need to track the in-memory configurations waiting to be applied. So they `VintageNetWizard.Backend` module is now responsible for that.

Also, starts to provide some consistency of data that will be shared between the socket and JSON endpoints. 

I think I want to change the function name `Backend.configure` to be `Backend.apply`, but will do that next.

Also, this just assumes one configuration for now for practical testing reasons, so we will want to expand to support many configurations soon.