### PR TITLE
Rename configure to apply

### DIFF
--- a/lib/vintage_net_wizard/backend.ex
+++ b/lib/vintage_net_wizard/backend.ex
@@ -28,9 +28,9 @@ defmodule VintageNetWizard.Backend do
   @callback configured?() :: boolean()
 
   @doc """
-  Configure the wifi network
+  Apply the WiFi configurations
   """
-  @callback configure([WiFiConfiguration.t()], state :: any()) :: :ok
+  @callback apply([WiFiConfiguration.t()], state :: any()) :: :ok
 
   @doc """
   Handle any message the is recieved by another process
@@ -70,9 +70,9 @@ defmodule VintageNetWizard.Backend do
     GenServer.call(__MODULE__, :configured?)
   end
 
-  @spec configure() :: :ok
-  def configure() do
-    GenServer.cast(__MODULE__, :configure)
+  @spec apply() :: :ok
+  def apply() do
+    GenServer.cast(__MODULE__, :apply)
   end
 
   @impl true
@@ -110,11 +110,11 @@ defmodule VintageNetWizard.Backend do
   end
 
   def handle_cast(
-        :configure,
+        :apply,
         %State{backend: backend, configurations: wifi_configs, backend_state: backend_state} =
           state
       ) do
-    :ok = apply(backend, :configure, [wifi_configs, backend_state])
+    :ok = apply(backend, :apply, [wifi_configs, backend_state])
     {:noreply, state}
   end
 

--- a/lib/vintage_net_wizard/backend/default.ex
+++ b/lib/vintage_net_wizard/backend/default.ex
@@ -36,7 +36,7 @@ defmodule VintageNetWizard.Backend.Default do
   end
 
   @impl true
-  def configure([cfg], _) do
+  def apply([cfg], _) do
     VintageNet.configure("wlan0", %{
       type: VintageNet.Technology.WiFi,
       wifi: %{

--- a/lib/vintage_net_wizard/backend/mock.ex
+++ b/lib/vintage_net_wizard/backend/mock.ex
@@ -68,7 +68,7 @@ defmodule VintageNetWizard.Backend.Mock do
   def configured?(), do: false
 
   @impl true
-  def configure(_cfgs, _state), do: :ok
+  def apply(_cfgs, _state), do: :ok
 
   @impl true
   def access_points(state), do: state

--- a/lib/vintage_net_wizard/web/socket.ex
+++ b/lib/vintage_net_wizard/web/socket.ex
@@ -51,8 +51,8 @@ defmodule VintageNetWizard.Web.Socket do
   end
 
   # Message from JS indicating the data should be saved
-  def websocket_handle({:json, %{"type" => "save"}}, state) do
-    _ = Backend.configure()
+  def websocket_handle({:json, %{"type" => "apply"}}, state) do
+    _ = Backend.apply()
     {:ok, state}
   end
 

--- a/priv/static/js/app.js
+++ b/priv/static/js/app.js
@@ -153,7 +153,7 @@ socket.onmessage = function (event) {
 
 const save = function () {
   payload = {
-    type: "save",
+    type: "apply",
     data: {}
   }
   socket.send(JSON.stringify(payload));


### PR DESCRIPTION
`Backend.configure` -> `Backend.apply`

Also had the client socket send an `apply` type to start moving to consistent naming conventions.  