### PR TITLE
Fix scanning access point not working on start

### DIFF
--- a/lib/vintage_net_wizard/backend/default.ex
+++ b/lib/vintage_net_wizard/backend/default.ex
@@ -9,7 +9,7 @@ defmodule VintageNetWizard.Backend.Default do
     if configured?() do
       :stop
     else
-      :ok = VintageNet.subscribe(["interface", "wlan0", "state"])
+      :ok = VintageNet.subscribe(["interface", "wlan0", "connection"])
       :ok = VintageNet.subscribe(["interface", "wlan0", "wifi", "access_points"])
       :ok = VintageNetWizard.run_wizard()
       {:ok, %{access_points: %{}}}
@@ -61,13 +61,8 @@ defmodule VintageNetWizard.Backend.Default do
     {:reply, {:access_points, access_points}, %{state | access_points: access_points}}
   end
 
-  def handle_info({VintageNet, ["interface", "wlan0", "state"], _, :configured, _meta}, state) do
+  def handle_info({VintageNet, ["interface", "wlan0", "connection"], _, :lan, _}, state) do
     :ok = scan()
-
-    {:noreply, state}
-  end
-
-  def handle_info({VintageNet, ["interface", "wlan0", "state"], _, _, _meta}, state) do
     {:noreply, state}
   end
 end


### PR DESCRIPTION
On SmartRent's FW I was experiencing the `default` backend not receiving the results of an access point scan on start.

My theory might be that there is a race condition between starting the scan and switching into AP mode (applying a configuration and that configuration restarting `wpa_supplicant`). I appear waiting for when we have a `:lan` connection we can scan and all things work well.

Will probably want to check the configuration to make sure it is in host mode before doing anything else for robustness, but I wanted to test out the theory first and allow others to test and think too to provide feedback on the idea.