### PR TITLE
Use the hostname as the AP so that two can run

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,5 +130,6 @@ mix burn
 ```
 
 Place the MicroSD card in the Raspberry Pi and power it out. You should see a
-WiFi access point appear shortly. Connect to the access point and then point
-your web browser at [http://192.168.24.1/](http://192.168.24.1/).
+WiFi access point appear with the SSID "nerves-wxyz" where "wxyz" are part of
+the serial number. Connect to the access point and then point your web browser
+at [http://192.168.24.1/](http://192.168.24.1/).

--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -21,11 +21,13 @@ defmodule VintageNetWizard do
   Change the WiFi module into access point mode
   """
   def into_ap_mode() do
+    ssid = get_hostname()
+
     config = %{
       type: VintageNet.Technology.WiFi,
       wifi: %{
         mode: :host,
-        ssid: "VintageNet Wizard",
+        ssid: ssid,
         key_mgmt: :none,
         scan_ssid: 1,
         ap_scan: 1,
@@ -48,4 +50,9 @@ defmodule VintageNetWizard do
   defdelegate start_server(), to: VintageNetWizard.Web.Endpoint
 
   defdelegate stop_server(), to: VintageNetWizard.Web.Endpoint
+
+  defp get_hostname() do
+    {:ok, hostname} = :inet.gethostname()
+    to_string(hostname)
+  end
 end


### PR DESCRIPTION
The hostname almost always has the serial number of a Nerves device
embedded in it so use it for the SSID. This makes it possible to run the
wizard on two devices in a room without a lot of confusion.