### PR TITLE
Switch to client mode back to AP when testing configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ following to your `config.exs`:
 config :vintage_net_wizard,
   port: 4001
 ```
+
 ### SSL
 
 To use SSL with the web UI, simply set the configuration flag:

--- a/json-api.md
+++ b/json-api.md
@@ -135,15 +135,47 @@ Response Code: 200
 ]
 ```
 
+## Get Configuration Status
+
+Get the current status of the configuration. This is useful after using
+the `/api/v1/apply` endpoint to figure out if the configurations that
+were provided work or not.
+
+Path: `/api/v1/configuration/status`
+
+Method: `GET`
+
+Request: Empty
+
+Response: `ConfigurationStatus`
+
+Response Code: 200
+
 ## Apply
 
 A POST to this endpoint applies the configuration and attempts to connect to the
-configured WiFi networks. To perform any additional configuration, the device
-will need to re-enter AP mode. This is done outside of this API.
+configured WiFi networks. This will return back to AP mode and you can use the
+`/api/v1/configuration/status` endpoint to get weather or not the configuration
+worked or not.
 
 Path: `/api/v1/apply`
 
 Method: `POST`
+
+Request: Empty
+
+Response: Empty
+
+Response Code: `202`
+
+## Complete the Configuration Process
+
+Finalize the configuration process. This will apply the configuration and
+not return to AP mode.
+
+Path: `/api/v1/complete`
+
+Method: `GET`
 
 Request: Empty
 
@@ -219,4 +251,12 @@ needed.
   "key_mgmt": KeyManagement,
   "password": Optional String
 }
+```
+
+### ConfigurationStatus
+
+```s
+not_configured - No configuration attempts have taken place
+good - A configuration was applied and is working
+bad - A configuration was applied and is not working
 ```

--- a/lib/vintage_net_wizard/web/api.ex
+++ b/lib/vintage_net_wizard/web/api.ex
@@ -10,6 +10,13 @@ defmodule VintageNetWizard.Web.Api do
   plug(:match)
   plug(:dispatch)
 
+  get "/configuration/status" do
+    with status <- Backend.configuration_status(),
+         {:ok, json_status} <- Jason.encode(status) do
+      send_json(conn, 200, json_status)
+    end
+  end
+
   get "/access_points" do
     {:ok, access_points} =
       Backend.access_points()
@@ -24,6 +31,14 @@ defmodule VintageNetWizard.Web.Api do
     |> Backend.set_priority_order()
 
     send_json(conn, 204, "")
+  end
+
+  get "/complete" do
+    _ = send_json(conn, 202, "")
+    :ok = Backend.apply()
+    :ok = VintageNetWizard.stop_server()
+
+    conn
   end
 
   get "/configurations" do

--- a/lib/vintage_net_wizard/web/router.ex
+++ b/lib/vintage_net_wizard/web/router.ex
@@ -59,8 +59,18 @@ defmodule VintageNetWizard.Web.Router do
   end
 
   get "/apply" do
+    conn = render_page(conn, "apply.html")
     :ok = Backend.apply()
-    render_page(conn, "apply.html")
+
+    conn
+  end
+
+  get "/complete" do
+    conn = render_page(conn, "complete.html")
+    :ok = Backend.apply()
+    :ok = VintageNetWizard.stop_server()
+
+    conn
   end
 
   forward("/api/v1", to: VintageNetWizard.Web.Api)

--- a/priv/static/js/apply.js
+++ b/priv/static/js/apply.js
@@ -1,0 +1,61 @@
+"use strict";
+
+(() => {
+  let hasGoodConfiguration = false;
+  const statusInterval = setInterval(get_status, 1000);
+  const contentDiv = document.querySelector(".content");
+
+  function completeConfiguration() {
+    fetch("/api/v1/complete");
+  }
+
+  function get_status() {
+    timeout(1000, fetch("/api/v1/configuration/status"))
+      .then((resp) => resp.json())
+      .then(body => {
+        switch (body) {
+          case "not_configured":
+            contentDiv.innerHTML += ".";
+            break;
+          case "good":
+            if (hasGoodConfiguration) {
+              break;
+            } else {
+              clearInterval(statusInterval);
+              contentDiv.innerHTML =
+                `
+                <p>Connected successfully</p>
+                <p>Press Complete to exit the wizard and connect to the access point again. The wizard will exit automatically after 60 seconds.</p>
+                <a class="btn btn-primary" href="/complete">Next</a>
+                `
+              setTimeout(completeConfiguration, 60000);
+              hasGoodConfiguration = true;
+              break;
+            }
+          case "bad":
+            clearInterval(statusInterval);
+            console.log("boo");
+            break;
+        }
+      })
+      .catch(error => contentDiv.innerHTML += ".");
+  }
+
+  function timeout(ms, promise) {
+    return new Promise((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        reject(new Error("promise timeout"))
+      }, ms);
+      promise.then(
+        (res) => {
+          clearTimeout(timeoutId);
+          resolve(res);
+        },
+        (err) => {
+          clearTimeout(timeoutId);
+          reject(err);
+        }
+      );
+    })
+  }
+})();

--- a/priv/templates/complete.html.eex
+++ b/priv/templates/complete.html.eex
@@ -11,7 +11,7 @@
        <h1 class="text-right mt-2"><a href="/">VintageNet Wizard</a></h1>
 
        <div class="content">
-         Trying configuration
+         WiFi configuration is now complete!
        </div>
      </div>
      <footer class="py-3 bg-white shadow-sm w-100 text-muted">


### PR DESCRIPTION
There is probably a better way to do this, but this seems to work well.

The main change here is basically a state machine that uses the connection status reported by `vintage_net` to determine if the connection was okay and to switch back to AP mode.


I added a `Process.sleep` because I was running into timing issues where when I would switch back to AP mode it seemed that the low level bring up of `wpa_supplicant` was reading an old configuration file and getting internet-connected.  I am okay with using the `state` property to know if the configuration has changed, but I am not sure if that gets set once the `wpa_supplicant` file is written or not.

To finish this feature up we will need to add the support to make the final switch into client mode. For the API I think we will need a new API endpoint.