### PR TITLE
Timeout configuration attempts

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ config :vintage_net_wizard,
   backend: VintageNetWizard.Backend.Mock
 ```
 
+The default backend also timesout a configuration attempt if it is unable
+to connect to any of the specified networks within 15 sec (this might
+occur if the password is incorrect or otherwise faulty network). You can
+adjust this timeout in the config for more control of how long you want
+to allow the device to attempt the new configuration:
+
+```elixir
+config :vintage_net_wizard, configuration_timeout: 30_000
+```
+
 ## JSON API
 
 It is possible to write a smartphone app to configure your device using an API


### PR DESCRIPTION
Introduces a timeout when applying a new configuration to handle cases where the network password(s) might be incorrect or network is otherwise faulty and leaves the devices in a disconnected state.

Instead, if the device cannot connect to any networks in the config within the timeout, the device will revert back to AP mode and set `configuration_status: :bad`.

Timeout value defaults to `15 sec` but can be configured with `config :vintage_net_wizard, configuration_timeout: 12_000`