### PR TITLE
Handle trying configuration and applying aysnc from the browser

### DIFF
--- a/lib/vintage_net_wizard/backend/mock.ex
+++ b/lib/vintage_net_wizard/backend/mock.ex
@@ -98,6 +98,11 @@ defmodule VintageNetWizard.Backend.Mock do
   end
 
   @impl true
+  def handle_info({__MODULE__, :stop_server}, %{configuration_status: :good} = state) do
+    _ = Process.send_after(self(), {__MODULE__, :apply_config}, 1_000)
+    {:noreply, state}
+  end
+
   def handle_info({__MODULE__, :stop_server}, state) do
     _ = Process.send_after(self(), {__MODULE__, :apply_config}, 2_000)
     :ok = VintageNetWizard.stop_server()

--- a/lib/vintage_net_wizard/web/router.ex
+++ b/lib/vintage_net_wizard/web/router.ex
@@ -59,18 +59,7 @@ defmodule VintageNetWizard.Web.Router do
   end
 
   get "/apply" do
-    conn = render_page(conn, "apply.html")
-    :ok = Backend.apply()
-
-    conn
-  end
-
-  get "/complete" do
-    conn = render_page(conn, "complete.html")
-    :ok = Backend.apply()
-    :ok = VintageNetWizard.stop_server()
-
-    conn
+    render_page(conn, "apply.html")
   end
 
   forward("/api/v1", to: VintageNetWizard.Web.Api)

--- a/priv/static/js/apply.js
+++ b/priv/static/js/apply.js
@@ -1,61 +1,114 @@
 "use strict";
 
 (() => {
-  let hasGoodConfiguration = false;
-  const statusInterval = setInterval(get_status, 1000);
-  const contentDiv = document.querySelector(".content");
-
-  function completeConfiguration() {
-    fetch("/api/v1/complete");
+  const state = {
+    view: "trying",
+    dots: "",
+    completeTimer: null,
+    targetElem: document.querySelector(".content"),
+    configurationStatus: "not_configured",
+    completed: false
   }
 
-  function get_status() {
-    timeout(1000, fetch("/api/v1/configuration/status"))
-      .then((resp) => resp.json())
-      .then(body => {
-        switch (body) {
-          case "not_configured":
-            contentDiv.innerHTML += ".";
-            break;
-          case "good":
-            if (hasGoodConfiguration) {
-              break;
-            } else {
-              clearInterval(statusInterval);
-              contentDiv.innerHTML =
-                `
-                <p>Connected successfully</p>
-                <p>Press Complete to exit the wizard and connect to the access point again. The wizard will exit automatically after 60 seconds.</p>
-                <a class="btn btn-primary" href="/complete">Next</a>
-                `
-              setTimeout(completeConfiguration, 60000);
-              hasGoodConfiguration = true;
-              break;
-            }
-          case "bad":
-            clearInterval(statusInterval);
-            console.log("boo");
-            break;
+  function runGetStatus() {
+    setTimeout(getStatus, 1000);
+  }
+  
+  function getStatus() {
+    fetch("/api/v1/configuration/status")
+      .then(resp => resp.json())
+      .then(handleStatusResponse)
+      .catch(handleNetworkEorrResponse);
+  }
+
+  function handleStatusResponse(status) {
+    switch (status) {
+      case "not_configured":
+        state.dots = state.dots + ".";
+        render(state);
+        break;
+      case "good":
+        if (!status.completed) {
+          state.view = "configurationGood";
+          state.configurationStatus = status;
+          state.completeTimer = setTimeout(complete, 60000);
+          render(state);
         }
-      })
-      .catch(error => contentDiv.innerHTML += ".");
+        break;
+      case "bad":
+        state.view = "configurationBad";
+        state.configurationStatus = status;
+        render(state);
+        break;
+    }
   }
 
-  function timeout(ms, promise) {
-    return new Promise((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        reject(new Error("promise timeout"))
-      }, ms);
-      promise.then(
-        (res) => {
-          clearTimeout(timeoutId);
-          resolve(res);
-        },
-        (err) => {
-          clearTimeout(timeoutId);
-          reject(err);
-        }
-      );
-    })
+  function handleNetworkEorrResponse(e) {
+    state.dots = state.dots + ".";
+    render(state);
   }
+
+  function createCompleteLink({ targetElem }) {
+    const button = document.createElement("button");
+    button.classList.add("btn");
+    button.classList.add("btn-primary");
+    button.addEventListener("click", handleCompleteClick); 
+    button.innerHTML = "Complete";
+
+    targetElem.appendChild(button);
+  }
+
+  function handleCompleteClick(e) {
+    if (state.completeTimer) {
+      clearTimeout(state.completeTimer);
+      state.completeTimer = null;
+    }
+    complete();
+  }
+
+  function view({view, dots}) {
+    switch (view) {
+      case "trying":
+        return ["Trying Configuration" + dots, runGetStatus];
+      case "configurationGood":
+        return [`
+        <p>Configuration Okay</p>
+        <p>Press "Complete" to exit the Wizard and connect to the WiFi.</p>
+        <p>The Wizard will exit and connect to the WiFi automatically after 60 seconds.</p>
+        `, createCompleteLink];
+      case "configurationBad":
+        return [`
+        <p>Looks like there is a problem with your configuration.</p>
+        <p>Please ensure that your password(s) are correct and/or the
+        network you are trying to connect to is available.</p>
+        <a class="btn btn-primary" href="/">Configure</a>
+        `, null];
+      case "complete":
+        return ["Configuration complete", null];
+    }
+  }
+
+  function complete() {
+    fetch("/api/v1/complete")
+      .then(resp => {
+        state.view = "complete";
+        render(state);
+      });
+  }
+
+  function render(state) {
+    const [innerHTML, action] = view(state);
+    state.targetElem.innerHTML = innerHTML;
+    
+    if (action) {
+      action(state);
+    }
+  }
+
+  fetch("/api/v1/apply", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    }
+  }).then(resp => runGetStatus());
 })();

--- a/priv/templates/apply.html.eex
+++ b/priv/templates/apply.html.eex
@@ -11,7 +11,7 @@
        <h1 class="text-right mt-2"><a href="/">VintageNet Wizard</a></h1>
 
        <div class="content">
-         Trying configuration
+         Trying Configuration
        </div>
      </div>
      <footer class="py-3 bg-white shadow-sm w-100 text-muted">


### PR DESCRIPTION
We push the handling of apply and completing to the JS to avoid a race condition between HTTP assets and the connection breaking between client and host when switching out of AP mode.