### PR TITLE
Ensure bad state gets reset on retry

### DIFF
--- a/lib/vintage_net_wizard/backend/default.ex
+++ b/lib/vintage_net_wizard/backend/default.ex
@@ -111,7 +111,7 @@ defmodule VintageNetWizard.Backend.Default do
 
   def handle_info(
         {VintageNet, ["interface", "wlan0", "connection"], _, :internet, _},
-        %{state: :applying, data: %{configuration_status: :not_configured} = data} = state
+        %{state: :applying, data: data} = state
       ) do
     # Everything connected, so cancel our timeout
     _ = Process.cancel_timer(data.apply_configuration_timer)


### PR DESCRIPTION
If attempting to apply config gets the device in a bad state, it can never recover because we watch for successful connections only for `configuration_status` or `good` or `not_configured`. So this changes so we don't assert on `:not_configured` so it will attempt the same outcome if it is in a `:bad` state (which is like `:not_configured`)