### PR TITLE
Support reseting the backend back to initial state

### DIFF
--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -9,11 +9,14 @@ defmodule VintageNetWizard do
   This means the WiFi module will be put into access point
   mode and the web server will be started
   """
-  @spec run_wizard() :: :ok | {:error, any()}
+  @spec run_wizard() :: :ok
   def run_wizard() do
     with :ok <- into_ap_mode(),
          {:ok, _server} <- start_server() do
       :ok
+    else
+      # Already running is still ok
+      {:error, :already_started} -> :ok
     end
   end
 

--- a/lib/vintage_net_wizard/backend.ex
+++ b/lib/vintage_net_wizard/backend.ex
@@ -46,6 +46,12 @@ defmodule VintageNetWizard.Backend do
   """
   @callback configuration_status(state :: any()) :: configuration_status()
 
+  @doc """
+  Apply any actions required to set the backend back to an
+  initial default state
+  """
+  @callback reset() :: state :: any()
+
   defmodule State do
     @moduledoc false
     defstruct subscriber: nil, backend: nil, backend_state: nil, configurations: []
@@ -144,6 +150,14 @@ defmodule VintageNetWizard.Backend do
     GenServer.call(__MODULE__, :apply)
   end
 
+  @doc """
+  Reset the backend to an initial default state.
+  """
+  @spec reset() :: :ok
+  def reset() do
+    GenServer.call(__MODULE__, :reset)
+  end
+
   @impl true
   def init(backend) do
     {:ok,
@@ -220,6 +234,11 @@ defmodule VintageNetWizard.Backend do
       {:error, _} = error ->
         {:reply, error, state}
     end
+  end
+
+  def handle_call(:reset, _from, %State{backend: backend} = state) do
+    new_state = apply(backend, :reset, [])
+    {:reply, :ok, %{state | configurations: %{}, backend_state: new_state}}
   end
 
   @impl true

--- a/lib/vintage_net_wizard/backend/default.ex
+++ b/lib/vintage_net_wizard/backend/default.ex
@@ -12,10 +12,7 @@ defmodule VintageNetWizard.Backend.Default do
       :ok = VintageNet.subscribe(["interface", "wlan0", "wifi", "access_points"])
       :ok = VintageNetWizard.run_wizard()
 
-      %{
-        state: :configuring,
-        data: %{access_points: %{}, configuration_status: :not_configured}
-      }
+      initial_state()
     end
   end
 
@@ -69,6 +66,9 @@ defmodule VintageNetWizard.Backend.Default do
       {"Firmware UUID", kv["nerves_fw_uuid"]}
     ]
   end
+
+  @impl VintageNetWizard.Backend
+  def reset(), do: initial_state()
 
   @impl VintageNetWizard.Backend
   def handle_info(:configuration_timeout, %{data: data} = state) do
@@ -146,6 +146,13 @@ defmodule VintageNetWizard.Backend.Default do
   defp configured?() do
     config = VintageNet.get_configuration("wlan0")
     get_in(config, [:wifi, :ssid]) != nil and get_in(config, [:wifi, :mode]) != :host
+  end
+
+  defp initial_state() do
+    %{
+      state: :configuring,
+      data: %{access_points: %{}, configuration_status: :not_configured}
+    }
   end
 
   defp kv_to_map(key_values) do


### PR DESCRIPTION
Sometimes we need to reset back to an initial state on the backend. This makes it easy to do that with `VintageNetWizard.Backend.reset/0`