### PR TITLE
Reset backend when completing configuration

### DIFF
--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -9,11 +9,14 @@ defmodule VintageNetWizard do
   This means the WiFi module will be put into access point
   mode and the web server will be started
   """
-  @spec run_wizard() :: :ok | {:error, any()}
+  @spec run_wizard() :: :ok
   def run_wizard() do
     with :ok <- into_ap_mode(),
          {:ok, _server} <- start_server() do
       :ok
+    else
+      # Already running is still ok
+      {:error, :already_started} -> :ok
     end
   end
 

--- a/lib/vintage_net_wizard/backend.ex
+++ b/lib/vintage_net_wizard/backend.ex
@@ -46,6 +46,12 @@ defmodule VintageNetWizard.Backend do
   """
   @callback configuration_status(state :: any()) :: configuration_status()
 
+  @doc """
+  Apply any actions required to set the backend back to an
+  initial default state
+  """
+  @callback reset() :: state :: any()
+
   defmodule State do
     @moduledoc false
     defstruct subscriber: nil, backend: nil, backend_state: nil, configurations: []
@@ -144,6 +150,14 @@ defmodule VintageNetWizard.Backend do
     GenServer.call(__MODULE__, :apply)
   end
 
+  @doc """
+  Reset the backend to an initial default state.
+  """
+  @spec reset() :: :ok
+  def reset() do
+    GenServer.call(__MODULE__, :reset)
+  end
+
   @impl true
   def init(backend) do
     {:ok,
@@ -220,6 +234,11 @@ defmodule VintageNetWizard.Backend do
       {:error, _} = error ->
         {:reply, error, state}
     end
+  end
+
+  def handle_call(:reset, _from, %State{backend: backend} = state) do
+    new_state = apply(backend, :reset, [])
+    {:reply, :ok, %{state | configurations: %{}, backend_state: new_state}}
   end
 
   @impl true

--- a/lib/vintage_net_wizard/backend/default.ex
+++ b/lib/vintage_net_wizard/backend/default.ex
@@ -12,10 +12,7 @@ defmodule VintageNetWizard.Backend.Default do
       :ok = VintageNet.subscribe(["interface", "wlan0", "wifi", "access_points"])
       :ok = VintageNetWizard.run_wizard()
 
-      %{
-        state: :configuring,
-        data: %{access_points: %{}, configuration_status: :not_configured}
-      }
+      initial_state()
     end
   end
 
@@ -69,6 +66,9 @@ defmodule VintageNetWizard.Backend.Default do
       {"Firmware UUID", kv["nerves_fw_uuid"]}
     ]
   end
+
+  @impl VintageNetWizard.Backend
+  def reset(), do: initial_state()
 
   @impl VintageNetWizard.Backend
   def handle_info(:configuration_timeout, %{data: data} = state) do
@@ -146,6 +146,13 @@ defmodule VintageNetWizard.Backend.Default do
   defp configured?() do
     config = VintageNet.get_configuration("wlan0")
     get_in(config, [:wifi, :ssid]) != nil and get_in(config, [:wifi, :mode]) != :host
+  end
+
+  defp initial_state() do
+    %{
+      state: :configuring,
+      data: %{access_points: %{}, configuration_status: :not_configured}
+    }
   end
 
   defp kv_to_map(key_values) do

--- a/lib/vintage_net_wizard/web/api.ex
+++ b/lib/vintage_net_wizard/web/api.ex
@@ -36,6 +36,7 @@ defmodule VintageNetWizard.Web.Api do
   get "/complete" do
     _ = send_json(conn, 202, "")
     :ok = Backend.apply()
+    :ok = Backend.reset()
     :ok = VintageNetWizard.stop_server()
 
     conn


### PR DESCRIPTION
This is branched off of [reset_state](https://github.com/nerves-networking/vintage_net_wizard/tree/reset_state) branch. Look at this diff for the actual changes here until the other branch is merged - ⚠️ [diff](https://github.com/nerves-networking/vintage_net_wizard/compare/reset_state...reset_on_complete) ⚠️ 

Just a bit of cleanup so we don't store passwords around in memory after configurations have been applied and the wizard is shutdown.