### PR TITLE
Fix race between applying final config and reset

### DIFF
--- a/example/lib/wizard_example/button.ex
+++ b/example/lib/wizard_example/button.ex
@@ -38,6 +38,9 @@ defmodule WizardExample.Button do
 
   @impl true
   def handle_info(:timeout, state) do
+    # Reset the backend to make sure we start wizard
+    # in a clean state
+    :ok = VintageNetWizard.Backend.reset()
     :ok = VintageNetWizard.run_wizard()
     {:noreply, state}
   end

--- a/lib/vintage_net_wizard/backend.ex
+++ b/lib/vintage_net_wizard/backend.ex
@@ -273,6 +273,12 @@ defmodule VintageNetWizard.Backend do
         maybe_send(subscriber, {VintageNetWizard, message})
         {:noreply, %{state | backend_state: new_backend_state}}
 
+      {:noreply, %{state: :idle, data: %{configuration_status: :good}} = new_backend_state} ->
+        # idle state with good configuration means we've completed setup
+        # and wizard has been shut down. So let's clear configurations
+        # so aren't hanging around in memory
+        {:noreply, %{state | configurations: %{}, backend_state: new_backend_state}}
+
       {:noreply, new_backend_state} ->
         {:noreply, %{state | backend_state: new_backend_state}}
     end

--- a/lib/vintage_net_wizard/web/api.ex
+++ b/lib/vintage_net_wizard/web/api.ex
@@ -36,7 +36,6 @@ defmodule VintageNetWizard.Web.Api do
   get "/complete" do
     _ = send_json(conn, 202, "")
     :ok = Backend.apply()
-    :ok = Backend.reset()
     :ok = VintageNetWizard.stop_server()
 
     conn


### PR DESCRIPTION
When running `/complete` to finish the setup and disable wizard, there was a race between applying the configuration and reseting all the backend state that would cause the device to go back into AP mode.

This fixes that by asserting on the final backend state needed to confirm it is "completed".