### PR TITLE
Load previous configurations when starting the wizard

### DIFF
--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -3,6 +3,8 @@ defmodule VintageNetWizard do
   Documentation for VintageNetWizard.
   """
 
+  alias VintageNetWizard.Backend
+
   @doc """
   Run the wizard.
 
@@ -11,7 +13,8 @@ defmodule VintageNetWizard do
   """
   @spec run_wizard() :: :ok
   def run_wizard() do
-    with :ok <- into_ap_mode(),
+    with :ok <- Backend.load_configurations(),
+         :ok <- into_ap_mode(),
          {:ok, _server} <- start_server() do
       :ok
     else

--- a/lib/vintage_net_wizard/application.ex
+++ b/lib/vintage_net_wizard/application.ex
@@ -3,16 +3,23 @@ defmodule VintageNetWizard.Application do
 
   use Application
 
+  alias VintageNetWizard.{Backend, Web.Endpoint}
+
   @spec start(Application.start_type(), any()) :: {:error, any} | {:ok, pid()}
   def start(_type, _args) do
     backend = Application.get_env(:vintage_net_wizard, :backend, VintageNetWizard.Backend.Default)
 
     children = [
-      {VintageNetWizard.Web.Endpoint, []},
-      {VintageNetWizard.Backend, backend}
+      {Endpoint, []},
+      {Backend, backend}
     ]
 
     opts = [strategy: :one_for_one, name: VintageNetWizard.Supervisor]
     Supervisor.start_link(children, opts)
+  end
+
+  def start_phase(:wizard_startup, _start_type, _phase_args) do
+    unless Backend.configured?(), do: VintageNetWizard.run_wizard()
+    :ok
   end
 end

--- a/lib/vintage_net_wizard/backend/mock.ex
+++ b/lib/vintage_net_wizard/backend/mock.ex
@@ -7,25 +7,21 @@ defmodule VintageNetWizard.Backend.Mock do
   """
   @behaviour VintageNetWizard.Backend
 
-  @impl true
-  def init() do
-    # It either starts, already running, or will error. So
-    # don't need to care about the return
-    _ = VintageNetWizard.start_server()
-
+  @impl VintageNetWizard.Backend
+  def init(_) do
     initial_state()
   end
 
-  @impl true
+  @impl VintageNetWizard.Backend
   def apply(_configs, state) do
     Process.send_after(self(), {__MODULE__, :stop_server}, 2_000)
     {:ok, state}
   end
 
-  @impl true
+  @impl VintageNetWizard.Backend
   def access_points(%{access_points: access_points}), do: access_points
 
-  @impl true
+  @impl VintageNetWizard.Backend
   def device_info() do
     [
       {"Wi-Fi Address", "11:22:33:44:55:66"},
@@ -39,7 +35,17 @@ defmodule VintageNetWizard.Backend.Mock do
   @impl true
   def reset(), do: initial_state()
 
-  @impl true
+  @impl VintageNetWizard.Backend
+  def load_configurations() do
+    []
+  end
+
+  @impl VintageNetWizard.Backend
+  def configured?(_) do
+    false
+  end
+
+  @impl VintageNetWizard.Backend
   def handle_info({__MODULE__, :stop_server}, %{configuration_status: :good} = state) do
     _ = Process.send_after(self(), {__MODULE__, :apply_config}, 1_000)
     {:noreply, state}
@@ -64,7 +70,7 @@ defmodule VintageNetWizard.Backend.Mock do
     {:noreply, state}
   end
 
-  @impl true
+  @impl VintageNetWizard.Backend
   def configuration_status(%{configuration_status: configuration_status}) do
     configuration_status
   end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,8 @@ defmodule VintageNetWizard.MixProject do
   def application do
     [
       mod: {VintageNetWizard.Application, []},
-      extra_applications: [:logger, :eex]
+      extra_applications: [:logger, :eex],
+      start_phases: [{:wizard_startup, []}]
     ]
   end
 

--- a/test/support/test_backend.ex
+++ b/test/support/test_backend.ex
@@ -2,7 +2,7 @@ defmodule VintageNetWizard.Test.Backend do
   @behaviour VintageNetWizard.Backend
 
   @impl true
-  def init() do
+  def init(_) do
     {:ok, nil}
   end
 
@@ -13,7 +13,7 @@ defmodule VintageNetWizard.Test.Backend do
   def access_points(_), do: []
 
   @impl true
-  def configured?(), do: true
+  def configured?(_), do: true
 
   @impl true
   def apply(_cfgs, _state), do: :ok
@@ -23,4 +23,16 @@ defmodule VintageNetWizard.Test.Backend do
 
   @impl true
   def device_info(), do: []
+
+  @impl true
+  def configuration_status(_), do: :not_configured
+
+  @impl true
+  def reset(), do: nil
+
+  @impl true
+  def load_configurations(), do: []
+
+  @impl true
+  def configured?(_), do: false
 end


### PR DESCRIPTION
If a user holds a button to put the device back into AP mode, it will load the existing config from disk so they can just add to the config rather than totally replace.

Tested quite a bit with my rpi0