### PR TITLE
Don't start the wizard server on start

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,11 +64,29 @@ to your `mix` dependencies like so:
    {:vintage_net_wizard, "~> 0.1"}
 ```
 
+The configuration wizard is not started by default to allow for more control
+over business specific situations. You will need to add a call in your code
+when you want the device placed into AP mode and the wizard started:
+
+```elixir
+defmodule MyApp do
+  use Application
+
+  def start(_type, _args) do
+    if should_start_wizard?() do
+      VintageNetWizard.run_wizard
+    end
+    # ...
+    Supervisor.start_link(children, opts)
+  end
+end
+```
+
 This will be sufficient to try it out on a device that hasn't been configured
 yet. You will want to add a mechanism for forcing the wizard the run WiFi
 configuration again, such as holding a button for 5+ seconds. Take a look at
 [Running the example](#running-the-example) section for steps on setting up
-a button and running a quick example firmware on a device
+a button and running a quick example firmware on a device.
 
 ### Port
 

--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -3,6 +3,8 @@ defmodule VintageNetWizard do
   Documentation for VintageNetWizard.
   """
 
+  alias VintageNetWizard.{Backend, Web.Endpoint}
+
   @doc """
   Run the wizard.
 
@@ -11,7 +13,8 @@ defmodule VintageNetWizard do
   """
   @spec run_wizard() :: :ok
   def run_wizard() do
-    with :ok <- into_ap_mode(),
+    with :ok <- Backend.reset(),
+         :ok <- into_ap_mode(),
          {:ok, _server} <- start_server() do
       :ok
     else
@@ -53,9 +56,9 @@ defmodule VintageNetWizard do
     VintageNet.configure("wlan0", config)
   end
 
-  defdelegate start_server(), to: VintageNetWizard.Web.Endpoint
+  defdelegate start_server(), to: Endpoint
 
-  defdelegate stop_server(), to: VintageNetWizard.Web.Endpoint
+  defdelegate stop_server(), to: Endpoint
 
   defp get_hostname() do
     {:ok, hostname} = :inet.gethostname()

--- a/lib/vintage_net_wizard/backend.ex
+++ b/lib/vintage_net_wizard/backend.ex
@@ -134,14 +134,6 @@ defmodule VintageNetWizard.Backend do
   end
 
   @doc """
-  Ask the backend if the WiFi is configured
-  """
-  @spec configured?() :: boolean()
-  def configured?() do
-    GenServer.call(__MODULE__, :configured?)
-  end
-
-  @doc """
   Apply the configurations saved in the backend to
   the system.
   """

--- a/lib/vintage_net_wizard/backend/default.ex
+++ b/lib/vintage_net_wizard/backend/default.ex
@@ -5,15 +5,10 @@ defmodule VintageNetWizard.Backend.Default do
 
   @impl VintageNetWizard.Backend
   def init() do
-    if configured?() do
-      %{state: :idle, data: %{access_points: %{}, configuration_status: :good}}
-    else
-      :ok = VintageNet.subscribe(["interface", "wlan0", "connection"])
-      :ok = VintageNet.subscribe(["interface", "wlan0", "wifi", "access_points"])
-      :ok = VintageNetWizard.run_wizard()
+    :ok = VintageNet.subscribe(["interface", "wlan0", "connection"])
+    :ok = VintageNet.subscribe(["interface", "wlan0", "wifi", "access_points"])
 
-      initial_state()
-    end
+    initial_state()
   end
 
   @impl VintageNetWizard.Backend
@@ -143,11 +138,6 @@ defmodule VintageNetWizard.Backend.Default do
   def handle_info(_, state), do: {:noreply, state}
 
   defp scan(%{state: :configuring}), do: :ok
-
-  defp configured?() do
-    config = VintageNet.get_configuration("wlan0")
-    get_in(config, [:wifi, :ssid]) != nil and get_in(config, [:wifi, :mode]) != :host
-  end
 
   defp initial_state() do
     %{

--- a/test/support/test_backend.ex
+++ b/test/support/test_backend.ex
@@ -7,13 +7,7 @@ defmodule VintageNetWizard.Test.Backend do
   end
 
   @impl true
-  def scan(), do: :ok
-
-  @impl true
   def access_points(_), do: []
-
-  @impl true
-  def configured?(), do: true
 
   @impl true
   def apply(_cfgs, _state), do: :ok
@@ -23,4 +17,10 @@ defmodule VintageNetWizard.Test.Backend do
 
   @impl true
   def device_info(), do: []
+
+  @impl true
+  def reset(), do: %{}
+
+  @impl true
+  def configuration_status(_state), do: :not_configured
 end


### PR DESCRIPTION
There are some cases you may want the option to run the wizard, but not on startup (such as using a button only when you want the wizard).

This changes so that the necessary children start with the app, but the wizard is not start and the device is not forced into AP mode.