### PR TITLE
Turn off VintageNet persistence

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -7,7 +7,7 @@ config :nerves_runtime,
 
 config :vintage_net,
   resolvconf: "/dev/null",
-  persistence_dir: "./persistence",
+  persistence: VintageNet.Persistence.Null,
   bin_ip: "false"
 
 import_config "#{Mix.env()}.exs"


### PR DESCRIPTION
This cleans up the ./persistence directory that was being created.