### PR TITLE
Support name-based use of the wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,17 @@ configuration again, such as holding a button for 5+ seconds. Take a look at
 [Running the example](#running-the-example) section for steps on setting up
 a button and running a quick example firmware on a device.
 
+### DNS in AP-mode
+
+When the wizard is running, users go to either `http://192.168.0.1/` or
+`http://wifi.config/` to access the web user interface. The latter can be
+changed via the `config.exs`:
+
+```elixir
+config :vintage_net_wizard,
+  dns_name: "my-wifi-config.com"
+```
+
 ### Port
 
 `VintageNetWizard` starts a webserver on port `80` by default. If port `80` is

--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -29,6 +29,8 @@ defmodule VintageNetWizard do
   """
   def into_ap_mode() do
     ssid = get_hostname()
+    our_ip_address = {192, 168, 0, 1}
+    our_name = Application.get_env(:vintage_net_wizard, :dns_name, "wifi.config")
 
     config = %{
       type: VintageNet.Technology.WiFi,
@@ -43,14 +45,26 @@ defmodule VintageNetWizard do
       },
       ipv4: %{
         method: :static,
-        address: {192, 168, 0, 1},
+        address: our_ip_address,
         prefix_length: 24
       },
       dhcpd: %{
         # These are defaults and are reproduced here as documentation
         start: {192, 168, 0, 20},
         end: {192, 168, 0, 254},
-        max_leases: 235
+        max_leases: 235,
+        options: %{
+          dns: [our_ip_address],
+          subnet: {255, 255, 255, 0},
+          router: [our_ip_address],
+          domain: our_name,
+          search: [our_name]
+        }
+      },
+      dnsd: %{
+        records: [
+          {our_name, our_ip_address}
+        ]
       }
     }
 


### PR DESCRIPTION
This change starts a DNS server that resolves the name `wifi.config`. It
also updates the DHCP server responses so that clients automatically use
it.

This update had a side effect on MacOS on improving the initial
connection experience. The WiFi network appears to connect quickly now
rather than continuing to show connection progress happening for 10+
seconds after association.