### PR TITLE
Handle hostnames that result in invalid ssids

### DIFF
--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -3,7 +3,7 @@ defmodule VintageNetWizard do
   Documentation for VintageNetWizard.
   """
 
-  alias VintageNetWizard.{Backend, Web.Endpoint}
+  alias VintageNetWizard.{Backend, APMode, Web.Endpoint}
 
   @doc """
   Run the wizard.
@@ -21,7 +21,7 @@ defmodule VintageNetWizard do
   @spec run_wizard([Endpoint.opt()]) :: :ok | {:error, String.t()}
   def run_wizard(opts \\ []) do
     with :ok <- Backend.reset(),
-         :ok <- into_ap_mode(),
+         :ok <- APMode.into_ap_mode(),
          {:ok, _server} <- Endpoint.start_server(opts),
          :ok <- Backend.start_scan() do
       :ok
@@ -32,59 +32,7 @@ defmodule VintageNetWizard do
     end
   end
 
-  @doc """
-  Change the WiFi module into access point mode
-  """
-  def into_ap_mode() do
-    ssid = get_hostname()
-    our_ip_address = {192, 168, 0, 1}
-    our_name = Application.get_env(:vintage_net_wizard, :dns_name, "wifi.config")
-
-    config = %{
-      type: VintageNet.Technology.WiFi,
-      wifi: %{
-        networks: [
-          %{
-            mode: :host,
-            ssid: ssid,
-            key_mgmt: :none
-          }
-        ]
-      },
-      ipv4: %{
-        method: :static,
-        address: our_ip_address,
-        prefix_length: 24
-      },
-      dhcpd: %{
-        # These are defaults and are reproduced here as documentation
-        start: {192, 168, 0, 20},
-        end: {192, 168, 0, 254},
-        max_leases: 235,
-        options: %{
-          dns: [our_ip_address],
-          subnet: {255, 255, 255, 0},
-          router: [our_ip_address],
-          domain: our_name,
-          search: [our_name]
-        }
-      },
-      dnsd: %{
-        records: [
-          {our_name, our_ip_address}
-        ]
-      }
-    }
-
-    VintageNet.configure("wlan0", config, persist: false)
-  end
-
   defdelegate start_server(), to: Endpoint
 
   defdelegate stop_server(), to: Endpoint
-
-  defp get_hostname() do
-    {:ok, hostname} = :inet.gethostname()
-    to_string(hostname)
-  end
 end

--- a/lib/vintage_net_wizard/ap_mode.ex
+++ b/lib/vintage_net_wizard/ap_mode.ex
@@ -1,0 +1,67 @@
+defmodule VintageNetWizard.APMode do
+  @moduledoc """
+  This module contains utilities for configuration VintageNet in AP Mode
+  """
+
+  @doc """
+  Change the WiFi module into access point mode
+  """
+  @spec into_ap_mode() :: :ok | {:error, any()}
+  def into_ap_mode() do
+    hostname = get_hostname()
+    our_name = Application.get_env(:vintage_net_wizard, :dns_name, "wifi.config")
+
+    config = ap_mode_configuration(hostname, our_name)
+    VintageNet.configure("wlan0", config, persist: false)
+  end
+
+  @doc """
+  Return a configuration to put VintageNet into AP mode
+  """
+  @spec ap_mode_configuration(String.t(), String.t()) :: map()
+  def ap_mode_configuration(hostname, our_name) do
+    ssid = hostname
+    our_ip_address = {192, 168, 0, 1}
+
+    %{
+      type: VintageNet.Technology.WiFi,
+      wifi: %{
+        networks: [
+          %{
+            mode: :host,
+            ssid: ssid,
+            key_mgmt: :none
+          }
+        ]
+      },
+      ipv4: %{
+        method: :static,
+        address: our_ip_address,
+        prefix_length: 24
+      },
+      dhcpd: %{
+        # These are defaults and are reproduced here as documentation
+        start: {192, 168, 0, 20},
+        end: {192, 168, 0, 254},
+        max_leases: 235,
+        options: %{
+          dns: [our_ip_address],
+          subnet: {255, 255, 255, 0},
+          router: [our_ip_address],
+          domain: our_name,
+          search: [our_name]
+        }
+      },
+      dnsd: %{
+        records: [
+          {our_name, our_ip_address}
+        ]
+      }
+    }
+  end
+
+  defp get_hostname() do
+    {:ok, hostname} = :inet.gethostname()
+    to_string(hostname)
+  end
+end

--- a/lib/vintage_net_wizard/ap_mode.ex
+++ b/lib/vintage_net_wizard/ap_mode.ex
@@ -3,6 +3,8 @@ defmodule VintageNetWizard.APMode do
   This module contains utilities for configuration VintageNet in AP Mode
   """
 
+  @default_hostname "vintage_net_wizard"
+
   @doc """
   Change the WiFi module into access point mode
   """
@@ -20,7 +22,7 @@ defmodule VintageNetWizard.APMode do
   """
   @spec ap_mode_configuration(String.t(), String.t()) :: map()
   def ap_mode_configuration(hostname, our_name) do
-    ssid = hostname
+    ssid = sanitize_hostname_for_ssid(hostname)
     our_ip_address = {192, 168, 0, 1}
 
     %{
@@ -63,5 +65,17 @@ defmodule VintageNetWizard.APMode do
   defp get_hostname() do
     {:ok, hostname} = :inet.gethostname()
     to_string(hostname)
+  end
+
+  defp sanitize_hostname_for_ssid(<<ssid::32-bytes, _rest::binary>>) do
+    ssid
+  end
+
+  defp sanitize_hostname_for_ssid("") do
+    @default_hostname
+  end
+
+  defp sanitize_hostname_for_ssid(good_hostname) do
+    good_hostname
   end
 end

--- a/lib/vintage_net_wizard/backend/default.ex
+++ b/lib/vintage_net_wizard/backend/default.ex
@@ -1,7 +1,7 @@
 defmodule VintageNetWizard.Backend.Default do
   @behaviour VintageNetWizard.Backend
 
-  alias VintageNetWizard.WiFiConfiguration
+  alias VintageNetWizard.{APMode, WiFiConfiguration}
 
   @impl VintageNetWizard.Backend
   def init() do
@@ -85,7 +85,7 @@ defmodule VintageNetWizard.Backend.Default do
   def handle_info(:configuration_timeout, %{data: data} = state) do
     # If we get this timeout, something went wrong trying to apply
     # the configuration, i.e. bad password or faulty network
-    :ok = VintageNetWizard.into_ap_mode()
+    :ok = APMode.into_ap_mode()
 
     data =
       data
@@ -123,7 +123,7 @@ defmodule VintageNetWizard.Backend.Default do
     # wifi runs into a race condition. So, we wait a little
     # before trying to re-initialize the interface.
     Process.sleep(4_000)
-    :ok = VintageNetWizard.into_ap_mode()
+    :ok = APMode.into_ap_mode()
 
     data =
       data

--- a/test/vintage_net_wizard/ap_mode_test.exs
+++ b/test/vintage_net_wizard/ap_mode_test.exs
@@ -1,0 +1,30 @@
+defmodule VintageNetWizard.APModeTest do
+  use ExUnit.Case, async: true
+
+  alias VintageNetWizard.APMode
+
+  test "AP mode configuration has expected content" do
+    config = APMode.ap_mode_configuration("hostname", "our_name")
+
+    expected = %{
+      type: VintageNet.Technology.WiFi,
+      ipv4: %{address: {192, 168, 0, 1}, method: :static, prefix_length: 24},
+      wifi: %{networks: [%{key_mgmt: :none, mode: :host, ssid: "hostname"}]},
+      dhcpd: %{
+        end: {192, 168, 0, 254},
+        max_leases: 235,
+        options: %{
+          dns: [{192, 168, 0, 1}],
+          domain: "our_name",
+          router: [{192, 168, 0, 1}],
+          search: ["our_name"],
+          subnet: {255, 255, 255, 0}
+        },
+        start: {192, 168, 0, 20}
+      },
+      dnsd: %{records: [{"our_name", {192, 168, 0, 1}}]}
+    }
+
+    assert expected == config
+  end
+end

--- a/test/vintage_net_wizard/ap_mode_test.exs
+++ b/test/vintage_net_wizard/ap_mode_test.exs
@@ -27,4 +27,20 @@ defmodule VintageNetWizard.APModeTest do
 
     assert expected == config
   end
+
+  test "empty hostname gets changed to a valid ssid" do
+    config = APMode.ap_mode_configuration("", "our_name")
+
+    %{wifi: %{networks: [%{ssid: ssid}]}} = config
+
+    assert ssid == "vintage_net_wizard"
+  end
+
+  test "long hostname gets trimmed" do
+    config = APMode.ap_mode_configuration("1234567890123456789012345678901234567890", "our_name")
+
+    %{wifi: %{networks: [%{ssid: ssid}]}} = config
+
+    assert byte_size(ssid) <= 32
+  end
 end


### PR DESCRIPTION
This is intended to be merged after the code that extracted AP mode configuration