### PR TITLE
Add enterprise WiFi configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,16 +137,6 @@ config :vintage_net_wizard,
   backend: VintageNetWizard.Backend.Mock
 ```
 
-The default backend also times out a configuration attempt if it is unable
-to connect to any of the specified networks within 15 sec (this might
-occur if the password is incorrect or otherwise faulty network). You can
-adjust this timeout in the config for more control of how long you want
-to allow the device to attempt the new configuration:
-
-```elixir
-config :vintage_net_wizard, configuration_timeout: 30_000
-```
-
 ## JSON API
 
 It is possible to write a smartphone app to configure your device using an API

--- a/lib/vintage_net_wizard/backend/default.ex
+++ b/lib/vintage_net_wizard/backend/default.ex
@@ -31,7 +31,11 @@ defmodule VintageNetWizard.Backend.Default do
         ipv4: %{method: :dhcp}
       })
 
-    timeout = Application.get_env(:vintage_net_wizard, :configuration_timeout, 15_000)
+    timeout =
+      wifi_configurations
+      |> Enum.max_by(&WiFiConfiguration.timeout/1)
+      |> WiFiConfiguration.timeout()
+
     timer = Process.send_after(self(), :configuration_timeout, timeout)
 
     data =

--- a/lib/vintage_net_wizard/web/api.ex
+++ b/lib/vintage_net_wizard/web/api.ex
@@ -142,4 +142,11 @@ defmodule VintageNetWizard.Web.Api do
       message: "The password provided has invalid characters."
     })
   end
+
+  defp make_error_message({:error, :user_required}) do
+    Jason.encode!(%{
+      error: "user_required",
+      message: "A user is required."
+    })
+  end
 end

--- a/lib/vintage_net_wizard/wifi_configuration.ex
+++ b/lib/vintage_net_wizard/wifi_configuration.ex
@@ -6,13 +6,15 @@ defmodule VintageNetWizard.WiFiConfiguration do
   @opaque t ::
             VintageNetWizard.WiFiConfiguration.WPAPersonal.t()
             | VintageNetWizard.WiFiConfiguration.NoSecurity.t()
+            | VintageNetWizard.WiFiConfiguration.PEAPEnterprise.t()
 
   @type key_mgmt() :: :none | :wpa_psk
 
   alias VintageNetWizard.WiFiConfiguration.{
     Params,
     WPAPersonal,
-    NoSecurity
+    NoSecurity,
+    PEAPEnterprise
   }
 
   @doc """
@@ -38,6 +40,10 @@ defmodule VintageNetWizard.WiFiConfiguration do
     NoSecurity.from_params(params)
   end
 
+  def from_params(%{"key_mgmt" => "wpa_eap"} = params) do
+    PEAPEnterprise.from_params(params)
+  end
+
   @doc """
   Take a particular type of WiFi configuration and make into a configuration
   that `vintage_net` can use
@@ -49,9 +55,35 @@ defmodule VintageNetWizard.WiFiConfiguration do
   end
 
   @doc """
+  Get the expected timeout in milisecs for a particular configuration
+  """
+  @spec timeout(t()) :: non_neg_integer()
+  def timeout(%NoSecurity{}), do: 30_000
+  def timeout(%WPAPersonal{}), do: 30_000
+  def timeout(%PEAPEnterprise{}), do: 75_000
+
+  @doc """
   Get the `key_mgmt` type from the particular WiFi Configuration
   """
   @spec get_key_mgmt(t()) :: key_mgmt()
   def get_key_mgmt(%WPAPersonal{}), do: :wpa_psk
   def get_key_mgmt(%NoSecurity{}), do: :none
+  def get_key_mgmt(%PEAPEnterprise{}), do: :wpa_eap
+
+  @doc """
+  Convert a key_mgmt string into a key_mgmt
+  """
+  @spec key_mgmt_from_string(String.t()) :: {:ok, key_mgmt()} | {:error, :invalid_key_mgmt}
+  def key_mgmt_from_string("wpa_eap"), do: {:ok, :wpa_eap}
+  def key_mgmt_from_string("wpa_psk"), do: {:ok, :wpa_psk}
+  def key_mgmt_from_string("none"), do: {:ok, :none}
+  def key_mgmt_from_string(_), do: {:error, :invalid_key_mgmt}
+
+  @doc """
+  Get a human friendly name for the type of security of a WiFiConfiguration
+  """
+  @spec security_name(t()) :: String.t()
+  def security_name(%WPAPersonal{}), do: "WPA Personal"
+  def security_name(%NoSecurity{}), do: "None"
+  def security_name(%PEAPEnterprise{}), do: "WPA Enterprise"
 end

--- a/lib/vintage_net_wizard/wifi_configuration/peap_enterprise.ex
+++ b/lib/vintage_net_wizard/wifi_configuration/peap_enterprise.ex
@@ -1,0 +1,66 @@
+defmodule VintageNetWizard.WiFiConfiguration.PEAPEnterprise do
+  @moduledoc false
+
+  @behaviour VintageNetWizard.WiFiConfiguration
+
+  alias VintageNetWizard.WiFiConfiguration.Params
+
+  @type t :: %__MODULE__{
+          ssid: String.t(),
+          user: String.t(),
+          password: String.t(),
+          priority: non_neg_integer()
+        }
+
+  defstruct ssid: nil, user: nil, password: nil, priority: nil
+
+  @impl VintageNetWizard.WiFiConfiguration
+  @spec to_vintage_net_configuration(t()) :: map()
+  def to_vintage_net_configuration(%__MODULE__{
+        ssid: ssid,
+        user: user,
+        password: password,
+        priority: priority
+      }) do
+    %{
+      mode: :client,
+      key_mgmt: :wpa_eap,
+      eap: "PEAP",
+      phase2: "auth=MSCHAPV2",
+      ssid: ssid,
+      identity: user,
+      password: password
+    }
+    |> maybe_put_priority(priority)
+  end
+
+  @impl VintageNetWizard.WiFiConfiguration
+  @spec from_params(map()) :: {:ok, t()} | {:error, Params.param_error()}
+  def from_params(params) do
+    with {:ok, ssid} <- Params.ssid_from_params(params),
+         {:ok, password} <- Params.password_from_params(params, &validate_password/1),
+         {:ok, user} <- user_from_params(params) do
+      {:ok, %__MODULE__{ssid: ssid, password: password, user: user}}
+    else
+      error -> error
+    end
+  end
+
+  defp user_from_params(%{"user" => nil}), do: {:error, :user_required}
+  defp user_from_params(%{"user" => ssid}), do: {:ok, ssid}
+  defp user_from_params(_), do: {:error, :user_required}
+
+  defp maybe_put_priority(config, nil), do: config
+  defp maybe_put_priority(config, priority), do: Map.put(config, :priority, priority)
+
+  defp validate_password(nil), do: {:error, :password_required}
+  defp validate_password(""), do: {:error, :password_required}
+  defp validate_password(_pw), do: :ok
+
+  defimpl Jason.Encoder do
+    def encode(%{ssid: ssid}, opts) do
+      config = %{ssid: ssid, key_mgmt: :wpa_eap}
+      Jason.Encode.map(config, opts)
+    end
+  end
+end

--- a/priv/templates/configure_enterprise.html.eex
+++ b/priv/templates/configure_enterprise.html.eex
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>VintageNet Wizard</title>
+    <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
+    <link rel="stylesheet" type="text/css" href="/css/styles.css">
+  </head>
+  <body class="bg-light h-100">
+    <div class="container">
+      <h1 class="text-right mt-2"><a href="/">VintageNet Wizard</a></h1>
+
+      <div class="container">
+        <div class="row justify-content-center">
+            The Wi-Fi network "<%= ssid %>" requires a WPA2 password.
+          <form class="col-sm-8 mt-2" action="/ssid/<%= URI.encode(ssid) %>" method="POST">
+            <div class="form-group">
+              <label for="user">User</label>
+              <input type="text" class="form-control", id="user", name="user", value="<%= user %>">
+            </div>
+            <div class="form-group">
+              <label for="password">Password</label>
+              <div class="input-group">
+                <input type="password" class="form-control" id="password" name="password", value="<%= password %>">
+                <div class="input-group-addon">
+                  <a class="btn btn-light" onclick="showHidePassword()">
+                  <svg id="eye-slash" width="24" height="24" display="block" aria-hidden="true" focusable="false" data-prefix="far" data-icon="eye-slash" class="svg-inline--fa fa-eye-slash fa-w-20" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 512"><path fill="currentColor" d="M634 471L36 3.51A16 16 0 0 0 13.51 6l-10 12.49A16 16 0 0 0 6 41l598 467.49a16 16 0 0 0 22.49-2.49l10-12.49A16 16 0 0 0 634 471zM296.79 146.47l134.79 105.38C429.36 191.91 380.48 144 320 144a112.26 112.26 0 0 0-23.21 2.47zm46.42 219.07L208.42 260.16C210.65 320.09 259.53 368 320 368a113 113 0 0 0 23.21-2.46zM320 112c98.65 0 189.09 55 237.93 144a285.53 285.53 0 0 1-44 60.2l37.74 29.5a333.7 333.7 0 0 0 52.9-75.11 32.35 32.35 0 0 0 0-29.19C550.29 135.59 442.93 64 320 64c-36.7 0-71.71 7-104.63 18.81l46.41 36.29c18.94-4.3 38.34-7.1 58.22-7.1zm0 288c-98.65 0-189.08-55-237.93-144a285.47 285.47 0 0 1 44.05-60.19l-37.74-29.5a333.6 333.6 0 0 0-52.89 75.1 32.35 32.35 0 0 0 0 29.19C89.72 376.41 197.08 448 320 448c36.7 0 71.71-7.05 104.63-18.81l-46.41-36.28C359.28 397.2 339.89 400 320 400z"></path></svg>
+                  <svg id="eye-show" width="24" height="24" display="none" aria-hidden="true" focusable="false" data-prefix="far" data-icon="eye" class="svg-inline--fa fa-eye fa-w-18" role="img" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 576 512"><path fill="currentColor" d="M288 144a110.94 110.94 0 0 0-31.24 5 55.4 55.4 0 0 1 7.24 27 56 56 0 0 1-56 56 55.4 55.4 0 0 1-27-7.24A111.71 111.71 0 1 0 288 144zm284.52 97.4C518.29 135.59 410.93 64 288 64S57.68 135.64 3.48 241.41a32.35 32.35 0 0 0 0 29.19C57.71 376.41 165.07 448 288 448s230.32-71.64 284.52-177.41a32.35 32.35 0 0 0 0-29.19zM288 400c-98.65 0-189.09-55-237.93-144C98.91 167 189.34 112 288 112s189.09 55 237.93 144C477.1 345 386.66 400 288 400z"></path></svg>
+                  </a>
+                </div>
+              </div>
+            </div>
+            <input type="hidden" name="key_mgmt", value="wpa_eap">
+            <%= if error != "" do %>
+              <p class="text-danger"><%= error %></p>
+            <% end %>
+            <button type="submit" class="btn btn-primary">Submit</button>
+          </form>
+        </div>
+      </div> <!-- end form container -->
+    </div> <!-- end container -->
+
+    <footer class="py-3 bg-white shadow-sm w-100 text-muted">
+      <div class="container">
+        <%= for {info_name, info_data} <- device_info do %>
+          <div class="row">
+            <strong class="col-sm-2"><%= info_name %></strong>
+            <span class="col"><%= info_data %></span>
+          </div>
+        <% end %>
+    </footer>
+  </body>
+  <script>
+    function showHidePassword() {
+      var x = document.getElementById("password");
+      var eye = document.getElementById("eye-show");
+      var eye_slash = document.getElementById("eye-slash");
+
+      if (x.type === "password") {
+        x.type = "text";
+        eye.setAttribute("display", "block");
+        eye_slash.setAttribute("display", "none");
+      } else {
+        x.type = "password";
+        eye_slash.setAttribute("display", "block");
+        eye.setAttribute("display", "none");
+      }
+    }
+  </script>
+</html>

--- a/test/vintage_net_wizard/wifi_configuration/peap_enterprise_test.exs
+++ b/test/vintage_net_wizard/wifi_configuration/peap_enterprise_test.exs
@@ -1,0 +1,73 @@
+defmodule VintageNetWizard.WiFiConfiguration.PEAPEnterpriseTest do
+  use ExUnit.Case, async: true
+
+  alias VintageNetWizard.WiFiConfiguration.PEAPEnterprise
+
+  test "makes a configuration from good params" do
+    config = %PEAPEnterprise{ssid: "Enterprise", password: "123123123", user: "user"}
+
+    assert {:ok, ^config} =
+             PEAPEnterprise.from_params(%{
+               "ssid" => config.ssid,
+               "password" => config.password,
+               "user" => config.user
+             })
+  end
+
+  test "wont make a configuration from params with no password" do
+    assert {:error, :password_required} ==
+             PEAPEnterprise.from_params(%{
+               "ssid" => "Enterprise",
+               "user" => "user"
+             })
+  end
+
+  test "wont make a configuration from params with no user" do
+    assert {:error, :user_required} ==
+             PEAPEnterprise.from_params(%{
+               "ssid" => "Enterprise",
+               "password" => "password"
+             })
+  end
+
+  test "generates a configuration for vintage net no priority" do
+    config = %PEAPEnterprise{ssid: "Enterprise", password: "123123123", user: "user"}
+
+    expected_vintage_net_config = %{
+      mode: :client,
+      key_mgmt: :wpa_eap,
+      eap: "PEAP",
+      phase2: "auth=MSCHAPV2",
+      ssid: config.ssid,
+      identity: config.user,
+      password: config.password
+    }
+
+    assert expected_vintage_net_config == PEAPEnterprise.to_vintage_net_configuration(config)
+  end
+
+  test "generates a configuration for vintage net with a priority" do
+    config = %PEAPEnterprise{ssid: "Enterprise", password: "123123123", user: "user", priority: 1}
+
+    expected_vintage_net_config = %{
+      mode: :client,
+      key_mgmt: :wpa_eap,
+      eap: "PEAP",
+      phase2: "auth=MSCHAPV2",
+      ssid: config.ssid,
+      identity: config.user,
+      password: config.password,
+      priority: 1
+    }
+
+    assert expected_vintage_net_config == PEAPEnterprise.to_vintage_net_configuration(config)
+  end
+
+  test "can be made into JSON" do
+    config = %PEAPEnterprise{ssid: "Enterprise", password: "password", user: "user"}
+
+    json = "{\"key_mgmt\":\"wpa_eap\",\"ssid\":\"Enterprise\"}"
+
+    assert {:ok, json} == Jason.encode(config)
+  end
+end

--- a/test/vintage_net_wizard/wifi_configuration_test.exs
+++ b/test/vintage_net_wizard/wifi_configuration_test.exs
@@ -2,7 +2,7 @@ defmodule VintageNetWizard.WiFiConfigurationTest do
   use ExUnit.Case, async: true
 
   alias VintageNetWizard.WiFiConfiguration
-  alias VintageNetWizard.WiFiConfiguration.{NoSecurity, WPAPersonal}
+  alias VintageNetWizard.WiFiConfiguration.{NoSecurity, WPAPersonal, PEAPEnterprise}
 
   test "get the :none key_mgmt from NoSecurity config" do
     config = %NoSecurity{ssid: "Free WIFI"}
@@ -60,5 +60,51 @@ defmodule VintageNetWizard.WiFiConfigurationTest do
     }
 
     assert expected_vintage_net_config == WiFiConfiguration.to_vintage_net_configuration(config)
+  end
+
+  describe "Get a key_mgmt from a string" do
+    test "wpa_eap" do
+      assert {:ok, :wpa_eap} == WiFiConfiguration.key_mgmt_from_string("wpa_eap")
+    end
+
+    test "wpa_psk" do
+      assert {:ok, :wpa_psk} == WiFiConfiguration.key_mgmt_from_string("wpa_psk")
+    end
+
+    test "none" do
+      assert {:ok, :none} == WiFiConfiguration.key_mgmt_from_string("none")
+    end
+
+    test "invalid" do
+      assert {:error, :invalid_key_mgmt} == WiFiConfiguration.key_mgmt_from_string("blue")
+    end
+  end
+
+  describe "Get a human friendly name from a particular WiFiConfiguration" do
+    test "NoSecurity" do
+      assert "None" == WiFiConfiguration.security_name(%NoSecurity{})
+    end
+
+    test "WPAPersonal" do
+      assert "WPA Personal" == WiFiConfiguration.security_name(%WPAPersonal{})
+    end
+
+    test "PEAPEnterprise" do
+      assert "WPA Enterprise" == WiFiConfiguration.security_name(%PEAPEnterprise{})
+    end
+  end
+
+  describe "get expected timeouts" do
+    test "NoSecurity" do
+      assert 30_000 == WiFiConfiguration.timeout(%NoSecurity{})
+    end
+
+    test "WPAPersonal" do
+      assert 30_000 == WiFiConfiguration.timeout(%WPAPersonal{})
+    end
+
+    test "PEAPEnterprise" do
+      assert 75_000 == WiFiConfiguration.timeout(%PEAPEnterprise{})
+    end
   end
 end


### PR DESCRIPTION
Add support for enterprise WiFi configurations via username and
password. This changes the `WiFiConfiguration` to support a `:wpa_eap`
key_mgmt type, and adds some UI to allow users to provide the needed
credentials for configuration.