### PR TITLE
Move backend to a dynamic child

### DIFF
--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -20,9 +20,8 @@ defmodule VintageNetWizard do
   """
   @spec run_wizard([Endpoint.opt()]) :: :ok | {:error, String.t()}
   def run_wizard(opts \\ []) do
-    with :ok <- Backend.reset(),
-         :ok <- APMode.into_ap_mode(),
-         {:ok, _server} <- Endpoint.start_server(opts),
+    with :ok <- APMode.into_ap_mode(),
+         :ok <- Endpoint.start_server(opts),
          :ok <- Backend.start_scan() do
       :ok
     else

--- a/lib/vintage_net_wizard/application.ex
+++ b/lib/vintage_net_wizard/application.ex
@@ -8,8 +8,7 @@ defmodule VintageNetWizard.Application do
     backend = Application.get_env(:vintage_net_wizard, :backend, VintageNetWizard.Backend.Default)
 
     children = [
-      {VintageNetWizard.Web.Endpoint, []},
-      {VintageNetWizard.Backend, backend}
+      VintageNetWizard.Web.Endpoint
     ]
 
     opts = [strategy: :one_for_one, name: VintageNetWizard.Supervisor]

--- a/lib/vintage_net_wizard/backend/mock.ex
+++ b/lib/vintage_net_wizard/backend/mock.ex
@@ -16,10 +16,6 @@ defmodule VintageNetWizard.Backend.Mock do
   def init() do
     _ = Logger.info("Go to http://localhost:#{Application.get_env(:vintage_net_wizard, :port)}/")
 
-    # It either starts, already running, or will error. So
-    # don't need to care about the return
-    _ = Endpoint.start_server()
-
     initial_state()
   end
 
@@ -54,7 +50,6 @@ defmodule VintageNetWizard.Backend.Mock do
 
   def handle_info({__MODULE__, :stop_server}, state) do
     _ = Process.send_after(self(), {__MODULE__, :apply_config}, 2_000)
-    :ok = Endpoint.stop_server()
     {:noreply, state}
   end
 
@@ -63,7 +58,6 @@ defmodule VintageNetWizard.Backend.Mock do
   end
 
   def handle_info({__MODULE__, :apply_config}, state) do
-    {:ok, _} = Endpoint.start_server()
     {:noreply, %{state | configuration_status: :good}}
   end
 

--- a/lib/vintage_net_wizard/web/router.ex
+++ b/lib/vintage_net_wizard/web/router.ex
@@ -71,7 +71,7 @@ defmodule VintageNetWizard.Web.Router do
   post "/networks/new" do
     ssid = Map.get(conn.body_params, "ssid")
 
-    case Map.get(conn.body_params, "key_mgmt") do
+    case Map.get(conn.body_params, "security") do
       "none" ->
         {:ok, config} = WiFiConfiguration.from_params(conn.body_params)
         :ok = Backend.save(config)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,2 @@
 ExUnit.start()
+VintageNetWizard.run_wizard()


### PR DESCRIPTION
This just moves the Backend to be a dynamic child and started/stopped with the Endpoint. This will make things a lot easy to manage state in the future

Up next:
* move `complete` behavior out of `apply` so use-cases are separated
* add `stop_server`