### PR TITLE
Complete callback

### DIFF
--- a/lib/vintage_net_wizard/application.ex
+++ b/lib/vintage_net_wizard/application.ex
@@ -6,6 +6,7 @@ defmodule VintageNetWizard.Application do
   @spec start(Application.start_type(), any()) :: {:error, any} | {:ok, pid()}
   def start(_type, _args) do
     children = [
+      {Task.Supervisor, name: VintageNetWizard.TaskSupervisor},
       VintageNetWizard.Web.Endpoint
     ]
 

--- a/lib/vintage_net_wizard/application.ex
+++ b/lib/vintage_net_wizard/application.ex
@@ -5,8 +5,6 @@ defmodule VintageNetWizard.Application do
 
   @spec start(Application.start_type(), any()) :: {:error, any} | {:ok, pid()}
   def start(_type, _args) do
-    backend = Application.get_env(:vintage_net_wizard, :backend, VintageNetWizard.Backend.Default)
-
     children = [
       VintageNetWizard.Web.Endpoint
     ]

--- a/lib/vintage_net_wizard/backend/mock.ex
+++ b/lib/vintage_net_wizard/backend/mock.ex
@@ -7,7 +7,6 @@ defmodule VintageNetWizard.Backend.Mock do
   """
   @behaviour VintageNetWizard.Backend
 
-  alias VintageNetWizard.Web.Endpoint
   alias VintageNet.WiFi.AccessPoint
 
   require Logger
@@ -41,6 +40,9 @@ defmodule VintageNetWizard.Backend.Mock do
 
   @impl true
   def reset(), do: initial_state()
+
+  @impl true
+  def complete(_configs, state), do: {:ok, state}
 
   @impl true
   def handle_info({__MODULE__, :stop_server}, %{configuration_status: :good} = state) do

--- a/lib/vintage_net_wizard/web/api.ex
+++ b/lib/vintage_net_wizard/web/api.ex
@@ -36,7 +36,14 @@ defmodule VintageNetWizard.Web.Api do
 
   get "/complete" do
     :ok = Backend.complete()
-    :ok = Endpoint.stop_server()
+
+    _ =
+      Task.Supervisor.start_child(VintageNetWizard.TaskSupervisor, fn ->
+        # We don't want to stop the server before we
+        # send the response back.
+        :timer.sleep(3000)
+        Endpoint.stop_server()
+      end)
 
     send_json(conn, 202, "")
   end

--- a/test/support/test_backend.ex
+++ b/test/support/test_backend.ex
@@ -46,4 +46,7 @@ defmodule VintageNetWizard.Test.Backend do
   def start_scan(state) do
     state
   end
+
+  @impl true
+  def complete(_configs, state), do: {:ok, state}
 end

--- a/test/vintage_net_wizard/backend_test.exs
+++ b/test/vintage_net_wizard/backend_test.exs
@@ -55,4 +55,9 @@ defmodule VintageNetWizard.Backend.Test do
 
     assert {:error, :no_configurations} = Backend.apply()
   end
+
+  test "can complete with no configurations" do
+    :ok = Backend.reset()
+    assert :ok = Backend.complete()
+  end
 end

--- a/test/vintage_net_wizard/web/api_test.exs
+++ b/test/vintage_net_wizard/web/api_test.exs
@@ -8,13 +8,6 @@ defmodule VintageNetWizard.Web.ApiTest do
 
   @opts Api.init([])
 
-  setup do
-    # There is a race condition between these tests and
-    # handling state in the Mock backend. To be solved
-    # in the next change
-    VintageNetWizard.run_wizard()
-  end
-
   test "get a configuration status" do
     {_conn, status} = run_request(:get, "/configuration/status")
     assert Enum.member?(["not_configured", "good", "bad"], status)
@@ -307,6 +300,9 @@ defmodule VintageNetWizard.Web.ApiTest do
     Backend.subscribe()
 
     {conn, body} = run_request(:get, "/complete")
+
+    # Starts a task to kill the server after delivery
+    assert length(Task.Supervisor.children(VintageNetWizard.TaskSupervisor)) == 1
 
     assert_receive({VintageNetWizard, :completed})
 


### PR DESCRIPTION
This should make things a little easier to manage state and the flow configuration by splitting out the concern of `apply`ing and `complete`ing the configs. This reduces the need to do timing and such extreme flow control when adjusting configurations. It also means someone can use the wizard to apply a config for networks they might not actually be around.

Next up, allow someone to know if wizard is started and stopped