### PR TITLE
Add callbacks on exit

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,3 +184,25 @@ browser at [http://wifi.config](http://wifi.config/) or
 [http://192.168.0.1/](http://192.168.0.1/). If you've configured an SSL
 certificate, it's possible to use `https`. You may also need to change the
 `:dns_name` configuration to match the name on your SSL certificate.
+
+## Callbacks when Stopping
+
+There may be cases that your application needs to know when the wizard
+is stopped (i.e. start your app once the port is free, etc).
+
+For that, you can use the `:on_exit` options when calling
+`VintageNetWizard.run_wizard/1` and specify a `{module, function, args}` tuple of the function to call after the wizard has stopped.
+
+```elixir
+defmodule MyApp do
+  def start_wizard() do
+    VintageNetWizard.run_wizard(
+      on_exit: {__MODULE__, :handle_on_exit, []}
+    )
+  end
+
+  def handle_on_exit() do
+    Logger.info("VintageNetWizard stopped")
+  end
+end
+```

--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -14,6 +14,8 @@ defmodule VintageNetWizard do
   Options:
 
     - `:ssl` - A Keyword list of `:ssl.tls_server_options`
+    - `:on_exit` - `{module, function, args}` tuple specifying
+    callback to perform after stopping the server.
 
   See `Plug.SSL.configure/1` for more information about the
   SSL options.

--- a/lib/vintage_net_wizard/backend.ex
+++ b/lib/vintage_net_wizard/backend.ex
@@ -187,12 +187,6 @@ defmodule VintageNetWizard.Backend do
   @spec complete() :: :ok
   def complete() do
     GenServer.call(__MODULE__, :complete)
-
-    configuration_state()
-    |> Map.get(:subscriber)
-    |> maybe_send({VintageNetWizard, :completed})
-
-    :ok
   end
 
   @impl true

--- a/lib/vintage_net_wizard/callbacks.ex
+++ b/lib/vintage_net_wizard/callbacks.ex
@@ -1,0 +1,45 @@
+defmodule VintageNetWizard.Callbacks do
+  use Agent
+
+  require Logger
+
+  def start_link(callbacks) do
+    callbacks = Enum.reduce(callbacks, [], &validate_callback/2)
+    Agent.start_link(fn -> callbacks end, name: __MODULE__)
+  end
+
+  def list() do
+    Agent.get(__MODULE__, & &1)
+  end
+
+  def on_exit() do
+    list()
+    |> Keyword.get(:on_exit)
+    |> apply_callback()
+  end
+
+  defp apply_callback({mod, fun, args}) do
+    try do
+      apply(mod, fun, args)
+    rescue
+      err ->
+        Logger.error("[VintageNetWizard] Failed to run callback: #{inspect(err)}")
+    end
+  end
+
+  defp apply_callback(invalid), do: {:error, "invalid callback: #{inspect(invalid)}"}
+
+  defp validate_callback({_key, {mod, fun, args}} = callback, acc)
+       when is_atom(mod) and is_atom(fun) and is_list(args) do
+    [callback | acc]
+  end
+
+  defp validate_callback({key, invalid}, acc) do
+    _ =
+      Logger.warn(
+        "Skipping invalid callback option for #{inspect(key)}\n\tgot: #{inspect(invalid)}\n\texpected: {module, function, [args]}"
+      )
+
+    acc
+  end
+end

--- a/test/vintage_net_wizard/web/api_test.exs
+++ b/test/vintage_net_wizard/web/api_test.exs
@@ -304,8 +304,6 @@ defmodule VintageNetWizard.Web.ApiTest do
     # Starts a task to kill the server after delivery
     assert length(Task.Supervisor.children(VintageNetWizard.TaskSupervisor)) == 1
 
-    assert_receive({VintageNetWizard, :completed})
-
     assert conn.status == 202
     assert body == ""
   end

--- a/test/vintage_net_wizard_test.exs
+++ b/test/vintage_net_wizard_test.exs
@@ -1,4 +1,23 @@
 defmodule VintageNetWizardTest do
   use ExUnit.Case
   doctest VintageNetWizard
+
+  test "on_exit callback mfa" do
+    key = :on_exit_receive
+
+    # make sure we start with fresh state
+    VintageNetWizard.stop_wizard()
+
+    VintageNetWizard.run_wizard(on_exit: {__MODULE__, :callback_tester, [key]})
+    VintageNetWizard.stop_wizard()
+
+    assert_receive key
+  end
+
+  def callback_tester(key) do
+    # This is to be called from {m, f, a} callback and
+    # sends the message back to this process for
+    # assert_receive to verify it worked
+    send(self(), key)
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/nerves-networking/vintage_net_wizard/issues/122

Adds ability to specify callbacks to be used when the wizard starts and exits so the calling app can handle work during those phases.