### PR TITLE
Do not require internet connectivity to complete the wizard successfully

### DIFF
--- a/lib/vintage_net_wizard/backend/default.ex
+++ b/lib/vintage_net_wizard/backend/default.ex
@@ -106,9 +106,10 @@ defmodule VintageNetWizard.Backend.Default do
   end
 
   def handle_info(
-        {VintageNet, ["interface", "wlan0", "connection"], _, :internet, _},
+        {VintageNet, ["interface", "wlan0", "connection"], _, connectivity, _},
         %{state: :applying, data: %{configuration_status: :good} = data} = state
-      ) do
+      )
+      when connectivity in [:lan, :internet] do
     # Everything connected, so cancel our timeout
     _ = Process.cancel_timer(data.apply_configuration_timer)
 
@@ -116,9 +117,10 @@ defmodule VintageNetWizard.Backend.Default do
   end
 
   def handle_info(
-        {VintageNet, ["interface", "wlan0", "connection"], _, :internet, _},
+        {VintageNet, ["interface", "wlan0", "connection"], _, connectivity, _},
         %{state: :applying, data: data} = state
-      ) do
+      )
+      when connectivity in [:lan, :internet] do
     # Everything connected, so cancel our timeout
     _ = Process.cancel_timer(data.apply_configuration_timer)
 


### PR DESCRIPTION
Before, the wizard was completing successfully only when the access
point was verified by `VintageNet` to provide internet connectivity
(after successfully pinging a remote host).

The problem is that whether internet connectivity is needed or not is
application dependent. This commit therefore makes the wizard complete
successfully even if only LAN connectivity is available.