### PR TITLE
Show configuration status

### DIFF
--- a/lib/vintage_net_wizard/web/router.ex
+++ b/lib/vintage_net_wizard/web/router.ex
@@ -23,6 +23,7 @@ defmodule VintageNetWizard.Web.Router do
       configs ->
         render_page(conn, "index.html",
           configs: configs,
+          configuration_status: configuration_status_details(),
           format_security: &WiFiConfiguration.security_name/1,
           get_key_mgmt: &WiFiConfiguration.get_key_mgmt/1
         )
@@ -61,7 +62,7 @@ defmodule VintageNetWizard.Web.Router do
   end
 
   get "/networks" do
-    render_page(conn, "networks.html")
+    render_page(conn, "networks.html", configuration_status: configuration_status_details())
   end
 
   get "/networks/new" do
@@ -151,6 +152,28 @@ defmodule VintageNetWizard.Web.Router do
 
       true ->
         :none
+    end
+  end
+
+  defp configuration_status_details() do
+    case status = Backend.configuration_status() do
+      :good ->
+        %{
+          value: status,
+          class: "text-success",
+          title: "Device successfully connected to a network in the applied configuration"
+        }
+
+      :bad ->
+        %{
+          value: status,
+          class: "text-danger",
+          title:
+            "Device was unable to connect to any network in the configuration due to bad password or a timeout while attempting."
+        }
+
+      _ ->
+        %{value: status, class: "text-warning", title: "Device waiting to be configured."}
     end
   end
 end

--- a/priv/templates/index.html.eex
+++ b/priv/templates/index.html.eex
@@ -9,6 +9,15 @@
   <body class="bg-light h-100 d-flex flex-column">
      <div class="container access-points-container">
        <h1 class="text-right mt-2"><a href="/">VintageNet Wizard</a></h1>
+       <h3 class="text-left mt-2">
+        Configuration Status:
+        <span class="<%= configuration_status.class %>">
+          <%= configuration_status.value%>
+          <span style="bottom: 8px;right: 5px;position: relative" title="<%= configuration_status.title %>">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"><path d="M11 15h2v2h-2v-2zm0-8h2v6h-2V7zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>
+          </span>
+        </span>
+       </h3>
 
        Add one or more Wi-Fi access points to enable the device to connect to the network. Drag
        the networks into the order you prefer.
@@ -84,7 +93,7 @@
          })
        }
 
-       
+
        Sortable.create(document.querySelector(".configurations"), {
                handle: ".handle",
                draggable: ".configuration",

--- a/priv/templates/networks.html.eex
+++ b/priv/templates/networks.html.eex
@@ -9,6 +9,15 @@
   <body class="bg-light h-100 d-flex flex-column">
      <div class="container access-points-container">
        <h1 class="text-right mt-2"><a href="/">VintageNet Wizard</a></h1>
+       <h3 class="text-left mt-2">
+        Configuration Status:
+        <span class="<%= configuration_status.class %>">
+          <%= configuration_status.value%>
+          <span style="bottom: 8px;right: 5px;position: relative" title="<%= configuration_status.title %>">
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24"><path d="M11 15h2v2h-2v-2zm0-8h2v6h-2V7zm.99-5C6.47 2 2 6.48 2 12s4.47 10 9.99 10C17.52 22 22 17.52 22 12S17.52 2 11.99 2zM12 20c-4.42 0-8-3.58-8-8s3.58-8 8-8 8 3.58 8 8-3.58 8-8 8z"/></svg>
+          </span>
+        </span>
+       </h3>
        Choose the Wi-Fi network you want to add from the list below.
        <div class="my-3 p-3 bg-white rounded shadow-sm">
          <table class="table table-hover access-points-table">


### PR DESCRIPTION
Shows the configuration status at the top of the page on the index and `/networks` page so the user has a little more introspection of what might be happening. This will be helpful with captive portal as sometimes the page is lost and brought back up after successfully connecting to a networking, but the user is unaware of what happened.

Also adds a bit of help text that will show when hovering over the info icon to further clarify what the status means

![Screen Shot 2020-01-06 at 1 47 39 PM](https://user-images.githubusercontent.com/11321326/71848363-8a2d4a00-308c-11ea-8c1b-df41288f0a33.png)
![Screen Shot 2020-01-06 at 1 45 31 PM](https://user-images.githubusercontent.com/11321326/71848364-8a2d4a00-308c-11ea-9796-d212a75aa613.png)
