### PR TITLE
Add /complete endpoint

### DIFF
--- a/lib/vintage_net_wizard/web/router.ex
+++ b/lib/vintage_net_wizard/web/router.ex
@@ -6,6 +6,7 @@ defmodule VintageNetWizard.Web.Router do
 
   alias VintageNetWizard.{
     Backend,
+    Web.Endpoint,
     WiFiConfiguration
   }
 
@@ -110,6 +111,20 @@ defmodule VintageNetWizard.Web.Router do
 
   get "/apply" do
     render_page(conn, "apply.html", ssid: VintageNetWizard.APMode.ssid())
+  end
+
+  get "/complete" do
+    :ok = Backend.complete()
+
+    _ =
+      Task.Supervisor.start_child(VintageNetWizard.TaskSupervisor, fn ->
+        # We don't want to stop the server before we
+        # send the response back.
+        :timer.sleep(3000)
+        Endpoint.stop_server()
+      end)
+
+    render_page(conn, "complete.html")
   end
 
   forward("/api/v1", to: VintageNetWizard.Web.Api)

--- a/priv/templates/index.html.eex
+++ b/priv/templates/index.html.eex
@@ -62,7 +62,7 @@
        <a class="btn btn-primary" href="/networks">Add a New Network</a>
        <%= if length(configs) > 0 do %>
          <a class="btn btn-primary" href="/apply">Apply configuration</a>
-         <a class="btn btn-secondary" href="#" onclick="applyWithoutVerification()">Complete Without Verification</a>
+         <a class="btn btn-secondary" href="/complete" title="This will apply the configuration without any attempt to verify a successful network connection.">Complete Without Verification</a>
        <% end %>
      </div>
 


### PR DESCRIPTION
Also change the `Complete without verification` to use `/complete` endpoint and remove the JS confirm dialog to fix cases that the JS may not be working (like in captive portal)

![Screen Shot 2020-01-07 at 10 21 24 AM](https://user-images.githubusercontent.com/11321326/71915224-86570180-3138-11ea-84e1-9136e31bdc6c.png)