### PR TITLE
Fix adding networking not in AP list

### DIFF
--- a/lib/vintage_net_wizard/web/router.ex
+++ b/lib/vintage_net_wizard/web/router.ex
@@ -97,15 +97,16 @@ defmodule VintageNetWizard.Web.Router do
   post "/networks/new" do
     ssid = Map.get(conn.body_params, "ssid")
 
-    case Map.get(conn.body_params, "security") do
+    case Map.get(conn.body_params, "key_mgmt") do
       "none" ->
         {:ok, config} = WiFiConfiguration.from_params(conn.body_params)
         :ok = Backend.save(config)
 
         redirect(conn, "/")
 
-      "wpa_psk" ->
-        redirect(conn, "/ssid/#{ssid}")
+      key_mgmt ->
+        key_mgmt = String.to_existing_atom(key_mgmt)
+        render_password_page(conn, key_mgmt, ssid: ssid, password: "", error: "", user: "")
     end
   end
 

--- a/priv/templates/network_new.html.eex
+++ b/priv/templates/network_new.html.eex
@@ -17,10 +17,11 @@
            </div>
 
            <div class="form-group">
-             <label for="security">Security</label>
-             <select id="key_mgmt" name="security" class="custom-select js-security-select">
+             <label for="key_mgmt">Security</label>
+             <select id="key_mgmt" name="key_mgmt" class="custom-select js-security-select">
                <option value="none" selected>None</option>
                <option value="wpa_psk">WPA Personal</option>
+               <option value="wpa_eap">WPA Enterprise</option>
              </select>
            </div>
 


### PR DESCRIPTION
Adding a networking which isn't listed in the AP list was breaking because of mismatched param keys.

This also adds `wpa_eap` to the list of options when specifying the security of the custom network as well.