### PR TITLE
Add option 160 for RFC 7710

### DIFF
--- a/lib/vintage_net_wizard/ap_mode.ex
+++ b/lib/vintage_net_wizard/ap_mode.ex
@@ -47,11 +47,12 @@ defmodule VintageNetWizard.APMode do
         end: {192, 168, 0, 254},
         max_leases: 235,
         options: %{
-          dns: [our_ip_address],
-          subnet: {255, 255, 255, 0},
-          router: [our_ip_address],
-          domain: our_name,
-          search: [our_name]
+          :dns => [our_ip_address],
+          :subnet => {255, 255, 255, 0},
+          :router => [our_ip_address],
+          :domain => our_name,
+          :search => [our_name],
+          160 => ~s("#{our_name}")
         }
       },
       dnsd: %{

--- a/test/vintage_net_wizard/ap_mode_test.exs
+++ b/test/vintage_net_wizard/ap_mode_test.exs
@@ -14,11 +14,12 @@ defmodule VintageNetWizard.APModeTest do
         end: {192, 168, 0, 254},
         max_leases: 235,
         options: %{
-          dns: [{192, 168, 0, 1}],
-          domain: "our_name",
-          router: [{192, 168, 0, 1}],
-          search: ["our_name"],
-          subnet: {255, 255, 255, 0}
+          :dns => [{192, 168, 0, 1}],
+          :domain => "our_name",
+          :router => [{192, 168, 0, 1}],
+          :search => ["our_name"],
+          :subnet => {255, 255, 255, 0},
+          160 => ~s("our_name")
         },
         start: {192, 168, 0, 20}
       },


### PR DESCRIPTION
For https://github.com/nerves-networking/vintage_net_wizard/issues/156

Adds DHCP option 160 specifying the captive portal address for clients that support it.

![image](https://user-images.githubusercontent.com/11321326/72382573-c6892780-36d6-11ea-9668-a76d5264c98a.png)

Probably requires a `:vintage_net` change so that we are not mixing map key types...