### PR TITLE
Fix mix test when non-root

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -1,7 +1,9 @@
 use Mix.Config
 
 config :vintage_net_wizard,
-  backend: VintageNetWizard.Test.Backend
+  backend: VintageNetWizard.Test.Backend,
+  port: 4001,
+  captive_portal: false
 
 config :vintage_net,
   path: "#{File.cwd!()}/test/fixtures/root/bin"

--- a/test/vintage_net_wizard/ap_mode_test.exs
+++ b/test/vintage_net_wizard/ap_mode_test.exs
@@ -22,7 +22,7 @@ defmodule VintageNetWizard.APModeTest do
         },
         start: {192, 168, 0, 20}
       },
-      dnsd: %{records: [{"our_name", {192, 168, 0, 1}}, {"*", {192, 168, 0, 1}}]}
+      dnsd: %{records: [{"our_name", {192, 168, 0, 1}}]}
     }
 
     assert expected == config


### PR DESCRIPTION
When captive portal is enabled, it tries to listen on port 80 so that it
can issue redirects. This doesn't work unless you're running as root.