### PR TITLE
Add options for some branding

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,21 @@ configuration again, such as holding a button for 5+ seconds. Take a look at
 [Running the example](#running-the-example) section for steps on setting up
 a button and running a quick example firmware on a device.
 
+### UI Customization
+
+`VintageNetWizard` allows you to add customization to the UI. The three UI
+items that can be customized are: `:title`, `:title_color`, and
+`:button_color`.
+
+```elixir
+VintageNetWizard.run_wizard(
+  ui: [title: "My WiFi Wizard", title_color: "red", button_color: "#F0F0AD"]
+)
+```
+
+Each configuration option is optional and will fall back to
+`VintageNetWizard`s default colors and title.
+
 ### DNS in AP-mode
 
 When the wizard is running, users go to either `http://192.168.0.1/` or

--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -20,6 +20,7 @@ defmodule VintageNetWizard do
     * `:inactivity_timeout` - Minutes to run before automatically stopping (defaults to 10 minutes)
     * `:on_exit` - `{module, function, args}` tuple specifying callback to perform after stopping the server.
     * `:ssl` - A Keyword list of `:ssl.tls_server_options`. See `Plug.SSL.configure/1`.
+    * `:ui` - a subset of UI configuration for title, title color, and button color.
   """
   @spec run_wizard([Endpoint.opt()]) :: :ok | {:error, String.t()}
   def run_wizard(opts \\ []) do

--- a/priv/static/css/styles.css
+++ b/priv/static/css/styles.css
@@ -7,6 +7,10 @@ h1 a:hover {
   text-decoration: none;
 }
 
+.btn-primary {
+  border-color: currentcolor;
+}
+
 footer {
   margin: 0 auto;
   position: fixed;

--- a/priv/static/js/apply.js
+++ b/priv/static/js/apply.js
@@ -1,6 +1,6 @@
 "use strict";
 
-(() => {
+function applyConfiguration(button_color) {
   const state = {
     view: "trying",
     dots: "",
@@ -57,6 +57,10 @@
     if (view === "configurationBad") {
       btnClass = "btn-danger";
       btnText = "Complete Without Verification";
+    }
+
+    if (view != "configurationBad") {
+      button.style.backgroundColor = button_color;
     }
 
     button.classList.add("btn");
@@ -136,4 +140,4 @@
       "Content-Type": "application/json"
     }
   }).then(resp => runGetStatus());
-})();
+}

--- a/priv/templates/apply.html.eex
+++ b/priv/templates/apply.html.eex
@@ -2,13 +2,13 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title><%= title %></title>
+    <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
   </head>
   <body class="bg-light h-100 d-flex flex-column">
      <div class="container">
-       <h1 class="text-right mt-2"><a href="/"><%= title %></a></h1>
+       <h1 class="text-right mt-2"><a href="/" style="color: <%= ui.title_color %>"><%= ui.title %></a></h1>
        <div id="ssid" value="<%= ssid %>" hidden></div>
 
        <div class="content">
@@ -28,5 +28,6 @@
          <% end %>
      </footer>
      <script src="/js/apply.js"></script>
+     <script>applyConfiguration("<%= ui.button_color %>")</script>
   </body>
 </html>

--- a/priv/templates/complete.html.eex
+++ b/priv/templates/complete.html.eex
@@ -2,13 +2,13 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title><%= title %></title>
+    <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
   </head>
   <body class="bg-light h-100 d-flex flex-column">
      <div class="container">
-       <h1 class="text-right mt-2"><a href="/"><%= title %></a></h1>
+       <h1 class="text-right mt-2"><a href="/" style="color: <%= ui.title_color %>"><%= ui.title %></a></h1>
 
        <div class="content">
          WiFi configuration is complete!
@@ -24,5 +24,6 @@
          <% end %>
      </footer>
      <script src="/js/apply.js"></script>
+     <script>applyConfiguration("<%= ui.button_color %>")</script>
   </body>
 </html>

--- a/priv/templates/configure_enterprise.html.eex
+++ b/priv/templates/configure_enterprise.html.eex
@@ -2,13 +2,13 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title><%= title %></title>
+    <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
   </head>
   <body class="bg-light h-100">
     <div class="container">
-      <h1 class="text-right mt-2"><a href="/"><%= title %></a></h1>
+      <h1 class="text-right mt-2"><a href="/" style="color: <%= ui.title_color %>"><%= ui.title %></a></h1>
 
       <div class="container">
         <div class="text-center">
@@ -37,7 +37,9 @@
             <%= if error != "" do %>
               <p class="text-danger"><%= error %></p>
             <% end %>
-            <button type="submit" class="btn btn-primary">Submit</button>
+            <button type="submit" class="btn btn-primary" style="background-color:<%= ui.button_color %>">
+              Submit
+            </button>
           </form>
         </div>
       </div> <!-- end form container -->

--- a/priv/templates/configure_password.html.eex
+++ b/priv/templates/configure_password.html.eex
@@ -2,13 +2,13 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title><%= title %></title>
+    <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
   </head>
   <body class="bg-light h-100">
     <div class="container">
-      <h1 class="text-right mt-2"><a href="/"><%= title %></a></h1>
+      <h1 class="text-right mt-2"><a href="/" style="color: <%= ui.title_color %>"><%= ui.title %></a></h1>
       <div class="container">
         <div class="text-center">
           <p>Authentication Required</p>
@@ -32,7 +32,9 @@
             <%= if error != "" do %>
               <p class="text-danger"><%= error %></p>
             <% end %>
-            <button type="submit" class="btn btn-primary">Submit</button>
+            <button type="submit" class="btn btn-primary" style="background-color:<%= ui.button_color %>">
+              Submit
+            </button>
           </form>
         </div>
       </div> <!-- end form container -->

--- a/priv/templates/index.html.eex
+++ b/priv/templates/index.html.eex
@@ -2,13 +2,13 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title><%= title %></title>
+    <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
   </head>
   <body class="bg-light h-100 d-flex flex-column">
      <div class="container access-points-container">
-       <h1 class="text-right mt-2"><a href="/"><%= title %></a></h1>
+       <h1 class="text-right mt-2"><a href="/" style="color: <%= ui.title_color %>"><%= ui.title %></a></h1>
        <h3 class="text-left mt-2">
         Configuration status:
         <span class="<%= configuration_status.class %>">
@@ -58,10 +58,16 @@
 
        <p><i>Drag the networks to change the order that they will be tried</i></p>
 
-       <a class="btn btn-primary" href="/networks">Add a new network</a>
+       <a class="btn btn-primary" style="background-color:<%= ui.button_color %>" href="/networks">
+         Add a new network
+       </a>
        <%= if length(configs) > 0 do %>
-         <a class="btn btn-primary" href="/apply">Apply configuration</a>
-         <a class="btn btn-secondary" href="/complete" title="This will apply the configuration without any attempt to verify a successful network connection.">Complete without verification</a>
+         <a class="btn btn-primary" style="background-color:<%= ui.button_color %>" href="/apply">
+           Apply configuration
+         </a>
+         <a class="btn btn-secondary" href="/complete" title="This will apply the configuration without any attempt to verify a successful network connection.">
+           Complete without verification
+         </a>
        <% end %>
      </div>
 

--- a/priv/templates/network_new.html.eex
+++ b/priv/templates/network_new.html.eex
@@ -2,13 +2,13 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title><%= title %></title>
+    <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
   </head>
   <body class="bg-light h-100 d-flex flex-column">
      <div class="container">
-       <h1 class="text-right mt-2"><a href="/"><%= title %></a></h1>
+       <h1 class="text-right mt-2"><a href="/" style="color: <%= ui.title_color %>"><%= ui.title %></a></h1>
        <div class="row justify-content-center">
          <form class="col-sm-8 mt-3" action="/networks/new" method="POST">
            <div class="form-group">
@@ -25,7 +25,9 @@
              </select>
            </div>
 
-           <button type="submit" class="btn btn-primary">Next</button>
+           <button type="submit" class="btn btn-primary" style="background-color:<%= ui.button_color %>">
+             Next
+           </button>
          </form>
          </div>
      </div> <!-- end form container -->

--- a/priv/templates/networks.html.eex
+++ b/priv/templates/networks.html.eex
@@ -2,13 +2,13 @@
 <html>
   <head>
     <meta charset="UTF-8">
-    <title><%= title %></title>
+    <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">
   </head>
   <body class="bg-light h-100 d-flex flex-column">
      <div class="container access-points-container">
-       <h1 class="text-right mt-2"><a href="/"><%= title %></a></h1>
+       <h1 class="text-right mt-2"><a href="/" style="color: <%= ui.title_color %>"><%= ui.title %></a></h1>
        <h3 class="text-left mt-2">
         Configuration status:
         <span class="<%= configuration_status.class %>">
@@ -33,7 +33,7 @@
          </table>
        </div>
 
-       <a class="btn btn-primary" href="/networks/new">Add another network</a>
+       <a class="btn btn-primary" href="/networks/new" style="background-color:<%= ui.button_color %>">Add another network</a>
      </div>
 
      <footer class="py-3 bg-white shadow-sm w-100 text-muted">


### PR DESCRIPTION
This adds three branding options that can be passed into
`VintageNetWizard.run_wizard/1`: `:title`, `:title_color`, and
`:button_color`.

The fallback values are the values of the colors and title before the
branding options were added.

This uses `Plug`'s `builder_opts/0` function for the `:dispatch` plug in
order to pass router initialization arguments into the routes. This
is exposed in the routes a `opts` and will contain the `:ui` field if
configured by the caller.

This removes support the `:ui_title` application configuration.