### PR TITLE
Fix issues with title not appearing on the apply page

### DIFF
--- a/priv/static/js/apply.js
+++ b/priv/static/js/apply.js
@@ -1,6 +1,6 @@
 "use strict";
 
-function applyConfiguration(button_color) {
+function applyConfiguration(title, button_color) {
   const state = {
     view: "trying",
     dots: "",
@@ -8,7 +8,8 @@ function applyConfiguration(button_color) {
     targetElem: document.querySelector(".content"),
     configurationStatus: "not_configured",
     completed: false,
-    ssid: document.getElementById("ssid").getAttribute("value")
+    ssid: document.getElementById("ssid").getAttribute("value"),
+    title: title
   }
 
   function runGetStatus() {

--- a/priv/templates/apply.html.eex
+++ b/priv/templates/apply.html.eex
@@ -12,7 +12,7 @@
        <div id="ssid" value="<%= ssid %>" hidden></div>
 
        <div class="content">
-        <p>Please wait while the <%= title %> verifies your configuration.</p>
+        <p>Please wait while the <%= ui.title %> verifies your configuration.</p>
 
         <p>If this page doesn't update in 15-30 seconds, check that you're connected to
         the access point named "<b><%= ssid %></b>"</p>
@@ -28,6 +28,6 @@
          <% end %>
      </footer>
      <script src="/js/apply.js"></script>
-     <script>applyConfiguration("<%= ui.button_color %>")</script>
+     <script>applyConfiguration("<%= ui.title %>", "<%= ui.button_color %>")</script>
   </body>
 </html>

--- a/priv/templates/complete.html.eex
+++ b/priv/templates/complete.html.eex
@@ -24,6 +24,6 @@
          <% end %>
      </footer>
      <script src="/js/apply.js"></script>
-     <script>applyConfiguration("<%= ui.button_color %>")</script>
+     <script>applyConfiguration("<%= ui.title %>", "<%= ui.button_color %>")</script>
   </body>
 </html>


### PR DESCRIPTION
There was a runtime error when trying to render the apply page because
it did not look for the title in the `ui` map.

Also, during the dynamic content on the apply page the title was
"undefined" so now that is passed into the JavaScript for it to render
correctly.