### PR TITLE
Add option 114 for RFC 8910 (auto show wizard screen on iOS 14/big sur)

### DIFF
--- a/lib/vintage_net_wizard/ap_mode.ex
+++ b/lib/vintage_net_wizard/ap_mode.ex
@@ -47,11 +47,12 @@ defmodule VintageNetWizard.APMode do
         end: {192, 168, 0, 254},
         max_leases: 235,
         options: %{
-          dns: [our_ip_address],
-          subnet: {255, 255, 255, 0},
-          router: [our_ip_address],
-          domain: our_name,
-          search: [our_name]
+          :dns => [our_ip_address],
+          :subnet => {255, 255, 255, 0},
+          :router =>  [our_ip_address],
+          :domain => our_name,
+          :search => [our_name],
+          114 => ~s("#{Enum.join(Tuple.to_list(our_ip_address), ".")}")
         }
       },
       dnsd: %{


### PR DESCRIPTION
obviously building upon https://github.com/nerves-networking/vintage_net_wizard/pull/158

RFC 7710 was was superseded by 8910 and the option changed to 114. https://tools.ietf.org/html/rfc8910

best news is that iOS 14 and macOS big sur supports the option:
https://developer.apple.com/news/?id=q78sq5rv

NB: the ip address is used - since the client might have dns servers configured 1.1.1.1 google's or what not - disabling resolving of the hostname - ip works just fine and is not shown on the screens anyway.

basically it just works..

![Screenshot 2021-02-11 at 18 51 39](https://user-images.githubusercontent.com/1033636/107680753-8fe95c00-6c9e-11eb-8277-4c02cdb496e3.png)
![IMG_5101](https://user-images.githubusercontent.com/1033636/107680771-94ae1000-6c9e-11eb-85ad-30c46f6889ae.png)
