### PR TITLE
Initialize with viewport

### DIFF
--- a/priv/templates/apply.html.eex
+++ b/priv/templates/apply.html.eex
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/complete.html.eex
+++ b/priv/templates/complete.html.eex
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/configure_enterprise.html.eex
+++ b/priv/templates/configure_enterprise.html.eex
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/configure_password.html.eex
+++ b/priv/templates/configure_password.html.eex
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/index.html.eex
+++ b/priv/templates/index.html.eex
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/network_new.html.eex
+++ b/priv/templates/network_new.html.eex
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">

--- a/priv/templates/networks.html.eex
+++ b/priv/templates/networks.html.eex
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <title><%= ui.title %></title>
     <link rel="stylesheet" type="text/css" href="/css/bootstrap.min.css">
     <link rel="stylesheet" type="text/css" href="/css/styles.css">


### PR DESCRIPTION
refs #141

I noticed the lack of support for mobile browsers, ​digging a little into it I noticed the project already uses bootstrap 👍  So the way to get initial support for mobile browsers was fairly easy.

This is a preview of the new mobile flow:

![Screenshot 2021-04-07 at 22 54 57](https://user-images.githubusercontent.com/584259/113933590-103ac200-97f5-11eb-8c24-b101753813ef.png)
![Screenshot 2021-04-07 at 22 55 00](https://user-images.githubusercontent.com/584259/113933595-12048580-97f5-11eb-9c3a-154b75a1eeba.png)
![Screenshot 2021-04-07 at 22 55 03](https://user-images.githubusercontent.com/584259/113933598-129d1c00-97f5-11eb-9b5d-85b15b582674.png)
![Screenshot 2021-04-07 at 22 55 05](https://user-images.githubusercontent.com/584259/113933602-1335b280-97f5-11eb-9304-9d0a93e4fdc0.png)
![Screenshot 2021-04-07 at 22 55 08](https://user-images.githubusercontent.com/584259/113933606-13ce4900-97f5-11eb-93e8-b0c2d258550a.png)
![Screenshot 2021-04-07 at 22 55 09](https://user-images.githubusercontent.com/584259/113933609-1466df80-97f5-11eb-9bbb-9ae8b7ec454c.png)

I do not think this is enough to solve #141 but it's removing the immediate pain for mobile users <3