### PR TITLE
Fix WatchDog shutdown

### DIFF
--- a/lib/vintage_net_wizard.ex
+++ b/lib/vintage_net_wizard.ex
@@ -5,6 +5,8 @@ defmodule VintageNetWizard do
 
   alias VintageNetWizard.{BackendServer, APMode, Web.Endpoint}
 
+  @type stop_reason() :: :shutdown | :timeout
+
   @doc """
   Run the wizard.
 
@@ -70,13 +72,14 @@ defmodule VintageNetWizard do
   This will apply the current configuration in memory and completely
   stop the web and backend processes.
   """
-  @spec stop_wizard() :: :ok | {:error, String.t()}
-  def stop_wizard() do
+  @spec stop_wizard(stop_reason()) :: :ok | {:error, String.t()}
+  def stop_wizard(stop_reason \\ :shutdown) do
     with :ok <- BackendServer.complete(),
-         :ok <- Endpoint.stop_server() do
+         :ok <- Endpoint.stop_server(stop_reason) do
       :ok
     else
-      error -> error
+      error ->
+        error
     end
   end
 

--- a/lib/vintage_net_wizard/watch_dog.ex
+++ b/lib/vintage_net_wizard/watch_dog.ex
@@ -6,7 +6,7 @@ defmodule VintageNetWizard.WatchDog do
   # this server from shutting down the wizard call `pet/0` to reset the
   # timeout. The timeout should be in minutes.
 
-  use GenServer
+  use GenServer, restart: :transient
 
   require Logger
 
@@ -40,7 +40,7 @@ defmodule VintageNetWizard.WatchDog do
   @impl GenServer
   def handle_info(:timeout, inactivity_timeout) do
     Logger.info("[VintageNetWizard] inactivity timeout, shutting down wizard")
-    :ok = VintageNetWizard.stop_wizard()
+    :ok = VintageNetWizard.stop_wizard(:timeout)
     {:stop, :normal, inactivity_timeout}
   end
 

--- a/lib/vintage_net_wizard/web/api.ex
+++ b/lib/vintage_net_wizard/web/api.ex
@@ -42,7 +42,7 @@ defmodule VintageNetWizard.Web.Api do
         # We don't want to stop the server before we
         # send the response back.
         :timer.sleep(3000)
-        Endpoint.stop_server()
+        Endpoint.stop_server(:shutdown)
       end)
 
     send_json(conn, 202, "")

--- a/lib/vintage_net_wizard/web/router.ex
+++ b/lib/vintage_net_wizard/web/router.ex
@@ -126,7 +126,7 @@ defmodule VintageNetWizard.Web.Router do
         # We don't want to stop the server before we
         # send the response back.
         :timer.sleep(3000)
-        Endpoint.stop_server()
+        Endpoint.stop_server(:shutdown)
       end)
 
     render_page(conn, "complete.html", opts)


### PR DESCRIPTION
When the WatchDog would timeout due to inactivity, it would make a call
to itself to terminate while it was still processing the `:timeout`
message. This caused the shutdown process to never complete when
shutting down due to a timeout.

This fix allows the shutdown process to know if it should shutdown the
WatchDog server, in normal shutdown cases, or if it should allow the
WatchDog server to shut itself down.
