### PR TITLE
Allow phoenix_html 2.13+ and 3.0+

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -62,7 +62,7 @@ defmodule VintageNetWizard.MixProject do
     [
       # Dependencies for all targets
       {:plug_cowboy, "~> 2.0"},
-      {:phoenix_html, "~> 3.0"},
+      {:phoenix_html, "~> 2.13 or ~> 3.0"},
       {:jason, "~> 1.0"},
       {:vintage_net, "~> 0.9.1 or ~> 0.10.0 or ~> 0.11.0"},
       {:vintage_net_wifi, "~> 0.9.0 or ~> 0.10.0 or ~> 0.11.0"},


### PR DESCRIPTION
    Some packages don't support 3.0+ yet. This fixes this error:

    ```
    Failed to use "phoenix_html" (versions 2.14.0 to 2.14.3) because
      unnamed_package (version 0.4.30) requires ~> 2.14
      phoenix (version 1.5.10) requires ~> 2.13 or ~> 3.0
      vintage_net_wizard (version 0.4.5) requires ~> 3.0
    ```