### PR TITLE
Avoids overwritting connection details on shutdown

### DIFF
--- a/lib/vintage_net_wizard/backend_server.ex
+++ b/lib/vintage_net_wizard/backend_server.ex
@@ -281,6 +281,17 @@ defmodule VintageNetWizard.BackendServer do
   def handle_call(
         :complete,
         _from,
+        %State{backend_state: %{data: %{configuration_status: :good}}} = state
+      ) do
+    # As the configuration status is good, we are already completed setup and the configurations
+    # have been blanked in `handle_info/3` - calling complete on the backend will disconnect us and
+    # write over the saved configuration. Do nothing.
+    {:reply, :ok, state}
+  end
+
+  def handle_call(
+        :complete,
+        _from,
         %State{backend: backend, configurations: wifi_configs, backend_state: backend_state} =
           state
       ) do


### PR DESCRIPTION
Thanks for VintageNetWizard. It is so useful!

I have run into a slight issue when I have been configuring devices (Pi Zero Ws, but that's probably not relevant) though the captive portal interface through iOS. I think it could be an issue with other devices, but I haven't checked.

The scenario is as follows:

1. Set the SSID and password for Wifi
2. Choose "Apply configuration"
3. Usually the page telling me to wait 15 to 30 seconds is shown
4. My iOS device reconnects to my own network, the captive portal page disappears, and the Pi Zero is connected to the network(*) - all good
5. Ten minutes later the Pi Zero connection is dropped, and rebooting does not help.


The issue is caused by the following:

* ` VintageNetWizard.BackendServer.handle_info/3` receives an event notifying of the connection status being changed. If the status is good then [the configurations are cleared](https://github.com/nerves-networking/vintage_net_wizard/blob/338877f79b96e9ba1c2482260b95a1a44d7c66d8/lib/vintage_net_wizard/backend_server.ex#L316)
* On shutdown,  `VintageNetWizard.BackendServer.complete/0` is called. The cleared configuration [is applied](https://github.com/nerves-networking/vintage_net_wizard/blob/338877f79b96e9ba1c2482260b95a1a44d7c66d8/lib/vintage_net_wizard/backend_server.ex#L288) so the connection is dropped and the details forgotten by `VintageNet.Persistence`.
* `VintageNetWizard.WatchDog` stops the wizard, after 10 minutes of no activity.


This PR makes the `VintageNetWizard.BackendServer.complete/0` a no-op if the configuration has already successfully 
been applied, preventing the details being over-ridden on shutting down the wizard.


--- 
(*) I find it often take two goes applying the configuration before I can connect, but that is not a huge problem and not the subject of this PR. I do see the following message though:
```
[debug] wpa_supplicant(wlan0): Could not connect to kernel driver
``` 
