### PR TITLE
Support separate WiFi interface for AP

### DIFF
--- a/lib/vintage_net_wizard/ap_mode.ex
+++ b/lib/vintage_net_wizard/ap_mode.ex
@@ -18,6 +18,23 @@ defmodule VintageNetWizard.APMode do
   end
 
   @doc """
+  Change the WIFi module to exit AP mode and apply the wifi configs.
+  """
+  @spec exit_ap_mode(VintageNet.ifname(), [map()]) :: :ok | {:error, any()}
+  def exit_ap_mode(ifname, networks) do
+    configuration = VintageNet.get_configuration(ifname)
+
+    no_ap_mode =
+      configuration
+      |> Map.put(:ipv4, %{method: :dhcp})
+      |> Map.put(:vintage_net_wifi, %{networks: networks})
+      |> Map.delete(:dhcpd)
+      |> Map.delete(:dnsd)
+
+    VintageNet.configure(ifname, no_ap_mode)
+  end
+
+  @doc """
   Return a configuration to put VintageNet into AP mode
   """
   @spec ap_mode_configuration(String.t(), String.t()) :: map()

--- a/lib/vintage_net_wizard/backend.ex
+++ b/lib/vintage_net_wizard/backend.ex
@@ -19,11 +19,11 @@ defmodule VintageNetWizard.Backend do
   @doc """
   Do any initialization work like subscribing to messages
 
-  Will be passed the interface name that the backend should use. By default
-  this will be `"wlan0"`. If you want to use a different interface name you
-  can pass that in an option to `VintageNetWizard.run_wizard/1`.
+  Will be passed the interface names that the backend should use to scan and to set AP mode. By default
+  both will be `"wlan0"`. If you want to use different interface names you
+  can pass them in as options to `VintageNetWizard.run_wizard/1`.
   """
-  @callback init(VintageNet.ifname()) :: state :: any()
+  @callback init(VintageNet.ifname(), VintageNet.ifname()) :: state :: any()
 
   @doc """
   Get all the access points that the backend knowns about

--- a/lib/vintage_net_wizard/backend/mock.ex
+++ b/lib/vintage_net_wizard/backend/mock.ex
@@ -11,7 +11,7 @@ defmodule VintageNetWizard.Backend.Mock do
   require Logger
 
   @impl VintageNetWizard.Backend
-  def init(_ifname) do
+  def init(_ifname, _ap_ifname) do
     Logger.info("Go to http://localhost:#{Application.get_env(:vintage_net_wizard, :port)}/")
 
     initial_state()

--- a/lib/vintage_net_wizard/web/endpoint.ex
+++ b/lib/vintage_net_wizard/web/endpoint.ex
@@ -26,6 +26,7 @@ defmodule VintageNetWizard.Web.Endpoint do
           {:ssl, :ssl.tls_server_option()}
           | {:on_exit, {module(), atom(), list()}}
           | {:ifname, VintageNet.ifname()}
+          | {:ap_ifname, VintageNet.ifname()}
           | {:ui, [ui_opt()]}
           | Backend.opt()
 
@@ -180,12 +181,14 @@ defmodule VintageNetWizard.Web.Endpoint do
 
   defp get_backend_spec(opts) do
     ifname = Keyword.get(opts, :ifname, "wlan0")
+    ap_ifname = Keyword.get(opts, :ap_ifname, ifname)
     device_info = Keyword.get(opts, :device_info, [])
     configurations = Keyword.get(opts, :configurations, [])
 
     backend = Application.get_env(:vintage_net_wizard, :backend, VintageNetWizard.Backend.Default)
 
     BackendServer.child_spec(backend, ifname,
+      ap_ifname: ap_ifname,
       device_info: device_info,
       configurations: configurations
     )

--- a/mix.exs
+++ b/mix.exs
@@ -73,7 +73,7 @@ defmodule VintageNetWizard.MixProject do
 
   defp dialyzer() do
     [
-      flags: [:race_conditions, :unmatched_returns, :error_handling, :underspecs],
+      flags: [:unmatched_returns, :error_handling, :underspecs],
       list_unused_filters: true
     ]
   end

--- a/test/support/test_backend.ex
+++ b/test/support/test_backend.ex
@@ -2,7 +2,7 @@ defmodule VintageNetWizard.Test.Backend do
   @behaviour VintageNetWizard.Backend
 
   @impl VintageNetWizard.Backend
-  def init(_ifname) do
+  def init(_ifname, _ap_ifname) do
     {:ok, nil}
   end
 


### PR DESCRIPTION
NXP 88W8987 has two wifi interfaces: wlan0 and uap0.
uap0 must be used to provide the access point use for the Wizard
to successfully configure wlan0