### PR TITLE
Assign safer AP mode IP address

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Each configuration option is optional and will fall back to
 
 ### DNS in AP-mode
 
-When the wizard is running, users go to either `http://192.168.0.1/` or
+When the wizard is running, users go to either `http://172.16.61.0/` or
 `http://wifi.config/` to access the web user interface. The latter can be
 changed via the `config.exs`:
 
@@ -252,7 +252,7 @@ Place the MicroSD card in the Raspberry Pi and power it on. You should see a
 WiFi access point appear with the SSID "nerves-1234" where "1234" are part of
 the device's serial number. Connect to the access point and then point your web
 browser at [http://wifi.config](http://wifi.config/) or
-[http://192.168.0.1/](http://192.168.0.1/). If you've configured an SSL
+[http://172.16.61.0/](http://172.16.61.0/). If you've configured an SSL
 certificate, it's possible to use `https`. You may also need to change the
 `:dns_name` configuration to match the name on your SSL certificate.
 

--- a/lib/vintage_net_wizard/ap_mode.ex
+++ b/lib/vintage_net_wizard/ap_mode.ex
@@ -40,7 +40,7 @@ defmodule VintageNetWizard.APMode do
   @spec ap_mode_configuration(String.t(), String.t()) :: map()
   def ap_mode_configuration(hostname, our_name) do
     ssid = sanitize_hostname_for_ssid(hostname)
-    our_ip_address = {192, 168, 0, 1}
+    our_ip_address = {172, 16, 61, 0}
 
     %{
       type: VintageNetWiFi,
@@ -60,8 +60,8 @@ defmodule VintageNetWizard.APMode do
       },
       dhcpd: %{
         # These are defaults and are reproduced here as documentation
-        start: {192, 168, 0, 20},
-        end: {192, 168, 0, 254},
+        start: {172, 16, 61, 20},
+        end: {172, 16, 61, 254},
         max_leases: 235,
         options: %{
           dns: [our_ip_address],

--- a/test/vintage_net_wizard/ap_mode_test.exs
+++ b/test/vintage_net_wizard/ap_mode_test.exs
@@ -8,21 +8,21 @@ defmodule VintageNetWizard.APModeTest do
 
     expected = %{
       type: VintageNetWiFi,
-      ipv4: %{address: {192, 168, 0, 1}, method: :static, prefix_length: 24},
+      ipv4: %{address: {172, 16, 61, 0}, method: :static, prefix_length: 24},
       vintage_net_wifi: %{networks: [%{key_mgmt: :none, mode: :ap, ssid: "hostname"}]},
       dhcpd: %{
-        end: {192, 168, 0, 254},
+        end: {172, 16, 61, 254},
         max_leases: 235,
         options: %{
-          dns: [{192, 168, 0, 1}],
+          dns: [{172, 16, 61, 0}],
           domain: "our_name",
-          router: [{192, 168, 0, 1}],
+          router: [{172, 16, 61, 0}],
           search: ["our_name"],
           subnet: {255, 255, 255, 0}
         },
-        start: {192, 168, 0, 20}
+        start: {172, 16, 61, 20}
       },
-      dnsd: %{records: [{"our_name", {192, 168, 0, 1}}]}
+      dnsd: %{records: [{"our_name", {172, 16, 61, 0}}]}
     }
 
     assert expected == config


### PR DESCRIPTION
Use 172.16.61.0 instead of 192.168.0.0
since it is less likely to conflict with LANs

SRH-747