### PR TITLE
Support changing the subnet from 192.168.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,12 +111,13 @@ Each configuration option is optional and will fall back to
 ### DNS in AP-mode
 
 When the wizard is running, users go to either `http://192.168.0.1/` or
-`http://wifi.config/` to access the web user interface. The latter can be
+`http://wifi.config/` to access the web user interface. Both can be
 changed via the `config.exs`:
 
 ```elixir
 config :vintage_net_wizard,
-  dns_name: "my-wifi-config.com"
+  dns_name: "my-wifi-config.com",
+  subnet: "192.168.0.0"
 ```
 
 ### Port


### PR DESCRIPTION
The default 192.168.0.0 network works well for the wizard's IP addresses
and is easy to remember. There's confusion, though, when devices have
WiFi adapters that can run in both AP and station mode at the same time.
During the test step of connecting to an AP, if the network being tested
is also on the 192.168.0.0 subnet, then there will be two 192.168.0.0
networks. To minimize the chance of this, it's now possible to set the
subnet to something very unlikely to see.

This isn't the default since changing the default would invalidate
configuration instructions for people using the wizard in their
projects.
