### PR TITLE
Avoid crashes when terminating watchdog

### DIFF
--- a/lib/vintage_net_wizard/web/endpoint.ex
+++ b/lib/vintage_net_wizard/web/endpoint.ex
@@ -93,7 +93,7 @@ defmodule VintageNetWizard.Web.Endpoint do
   defp handle_watchdog(children, :timeout), do: children
 
   defp handle_watchdog(children, _other) do
-    :ok = DynamicSupervisor.terminate_child(__MODULE__, children[WatchDog])
+    _ = DynamicSupervisor.terminate_child(__MODULE__, children[WatchDog])
     children
   end
 


### PR DESCRIPTION
Don't match on :ok when terminating since the WatchDog might already have terminated