### PR TITLE
Fix compiler warning on router.ex + format files using plug format

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -5,5 +5,6 @@
     "{config,lib,test}/**/*.{ex,exs}",
     "example/mix.exs",
     "example/{config,lib,test}/**/*.{ex,exs}"
-  ]
+  ],
+  import_deps: [:plug]
 ]

--- a/lib/vintage_net_wizard/web/api.ex
+++ b/lib/vintage_net_wizard/web/api.ex
@@ -8,9 +8,9 @@ defmodule VintageNetWizard.Web.Api do
   alias VintageNetWizard.Web.Endpoint
   alias VintageNetWizard.WiFiConfiguration
 
-  plug(Plug.Parsers, parsers: [:json], json_decoder: Jason)
-  plug(:match)
-  plug(:dispatch)
+  plug Plug.Parsers, parsers: [:json], json_decoder: Jason
+  plug :match
+  plug :dispatch
 
   get "/configuration/status" do
     with status <- BackendServer.configuration_status(),

--- a/lib/vintage_net_wizard/web/router.ex
+++ b/lib/vintage_net_wizard/web/router.ex
@@ -10,15 +10,15 @@ defmodule VintageNetWizard.Web.Router do
     WiFiConfiguration
   }
 
-  plug(Plug.Logger, log: :debug)
-  plug(Plug.Static, from: {:vintage_net_wizard, "priv/static"}, at: "/")
-  plug(Plug.Parsers, parsers: [Plug.Parsers.URLENCODED, :json], json_decoder: Jason)
+  plug Plug.Logger, log: :debug
+  plug Plug.Static, from: {:vintage_net_wizard, "priv/static"}, at: "/"
+  plug Plug.Parsers, parsers: [Plug.Parsers.URLENCODED, :json], json_decoder: Jason
   # This route is polled by the front end to update its list of access points.
   # This can mean the user could potentially have the page open without knowing
   # it just polling this endpoint but still be inactive.
-  plug(VintageNetWizard.Plugs.Activity, excluding: ["/api/v1/access_points"])
-  plug(:match)
-  plug(:dispatch)
+  plug VintageNetWizard.Plugs.Activity, excluding: ["/api/v1/access_points"]
+  plug :match
+  plug :dispatch
 
   get "/" do
     case BackendServer.configurations() do

--- a/lib/vintage_net_wizard/web/router.ex
+++ b/lib/vintage_net_wizard/web/router.ex
@@ -18,7 +18,7 @@ defmodule VintageNetWizard.Web.Router do
   # it just polling this endpoint but still be inactive.
   plug(VintageNetWizard.Plugs.Activity, excluding: ["/api/v1/access_points"])
   plug(:match)
-  plug(:dispatch, builder_opts())
+  plug(:dispatch)
 
   get "/" do
     case BackendServer.configurations() do


### PR DESCRIPTION
fixes this error:

```
==> vintage_net_wizard
Compiling 16 files (.ex)
    warning: Plug.Builder.builder_opts/0 is deprecated. Pass :copy_opts_to_assign on "use Plug.Builder"
    │
 21 │   plug(:dispatch, builder_opts())
    │                   ~
    │
    └─ lib/vintage_net_wizard/web/router.ex:21:19: VintageNetWizard.Web.Router (module)

Generated vintage_net_wizard app
```
