### PR TITLE
Update HexDoc URL

### DIFF
--- a/example/config/config.exs
+++ b/example/config/config.exs
@@ -11,7 +11,7 @@ Application.start(:nerves_bootstrap)
 config :example, target: Mix.target()
 
 # Customize non-Elixir parts of the firmware. See
-# https://hexdocs.pm/nerves/advanced-configuration.html for details.
+# https://nerves.hexdocs.pm/advanced-configuration.html for details.
 
 config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 
@@ -21,7 +21,7 @@ config :nerves, :firmware, rootfs_overlay: "rootfs_overlay"
 config :nerves, source_date_epoch: "1611961839"
 
 # Use Ringlogger as the logger backend and remove :console.
-# See https://hexdocs.pm/ring_logger/readme.html for more information on
+# See https://ring-logger.hexdocs.pm/readme.html for more information on
 # configuring ring_logger.
 
 config :logger, backends: [RingLogger]

--- a/example/config/target.exs
+++ b/example/config/target.exs
@@ -25,8 +25,8 @@ config :nerves,
 
 # Configure the device for SSH IEx prompt access and firmware updates
 #
-# * See https://hexdocs.pm/nerves_ssh/readme.html for general SSH configuration
-# * See https://hexdocs.pm/ssh_subsystem_fwup/readme.html for firmware updates
+# * See https://nerves-ssh.hexdocs.pm/readme.html for general SSH configuration
+# * See https://ssh-subsystem-fwup.hexdocs.pm/readme.html for firmware updates
 
 keys =
   [

--- a/json-api.md
+++ b/json-api.md
@@ -264,7 +264,7 @@ This is the WiFi radio band that the access point is using.
 Flags are reported by access points. They can be used to know whether a password
 is required to join the network. Example flags are `"wpa2"`, `"psk"`, and
 `"eap"`. Flags are documented in the [`vintage_net_wifi`
-documentation](https://hexdocs.pm/vintage_net_wifi/VintageNetWiFi.AccessPoint.html)
+documentation](https://vintage-net-wifi.hexdocs.pm/VintageNetWiFi.AccessPoint.html)
 
 ### KeyManagement
 


### PR DESCRIPTION
Migrates HexDocs URLs to the 2026 format using hex_url_migrator.

<details>
<summary>⚠️ URL verification warnings from <code>hex_url_migrator --verify</code></summary>

```
❌ Verification failed for https://vintage-net-wifi.hexdocs.pm/VintageNetWiFi.AccessPoint.html): Status 404
⚠️ Verification finished: 4 success, 1 failure(s).
```

_Reported by the migrator's verifier. Note that `301`s are typically redirects (the target exists) and a trailing `)` is a markdown-link parsing artifact. Please review before merging._
</details>